### PR TITLE
Add frontend task list

### DIFF
--- a/frontend_tasks.md
+++ b/frontend_tasks.md
@@ -1,0 +1,47 @@
+# Frontend Tasks
+
+The following tasks outline the steps for building the SlurmCostManager frontend using modern design practices.
+
+## Initial Setup
+- Choose **React** with **Vite** for a fast development environment.
+- Configure **TypeScript** for type safety.
+- Integrate **Tailwind CSS** for utility-first styling.
+- Set up **ESLint** and **Prettier** for code quality.
+
+## Core Layout
+- Implement a responsive grid layout using Flexbox and CSS Grid.
+- Create a consistent header and sidebar navigation.
+- Add a footer with application metadata.
+- Ensure layout supports both light and dark themes.
+
+## Authentication Flow
+- Build login and registration forms with form validation.
+- Use JWT-based authentication with token refresh.
+- Include password reset and email verification pages.
+
+## Dashboard & Reports
+- Design a dashboard view summarizing resource usage and costs.
+- Implement interactive charts with libraries like **Chart.js** or **D3.js**.
+- Provide filter options to drill down by user, project, or date range.
+- Add accessible tables for detailed cost breakdowns.
+
+## Settings & User Management
+- Create profile management pages for users to update their information.
+- Support role-based access to administrative pages.
+- Include theme customization, such as color palette and layout density.
+
+## Accessibility & UX Enhancements
+- Ensure keyboard navigation for all interactive elements.
+- Add ARIA attributes and screen reader support.
+- Use animations sparingly for smoother interactions (e.g., fade transitions).
+
+## Testing & Optimization
+- Write unit tests with **Jest** and component tests with **React Testing Library**.
+- Configure end-to-end tests using **Cypress**.
+- Optimize assets with code splitting and lazy loading.
+
+## Deployment
+- Create production builds using Vite's build command.
+- Provide Docker configuration for containerized deployment.
+- Set up continuous deployment with GitHub Actions.
+


### PR DESCRIPTION
## Summary
- add a `frontend_tasks.md` document describing modern frontend tasks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68603fb540ec8324a2f0b73074b43dcb