### PR TITLE
Add frontend coding tasks

### DIFF
--- a/frontend_coding_tasks.md
+++ b/frontend_coding_tasks.md
@@ -1,0 +1,46 @@
+# Frontend Coding Tasks
+
+These tasks outline the concrete coding work required to implement the frontend features of SlurmCostManager based on `frontend_tasks.md`.
+
+## 1. Initial Setup
+- [ ] Scaffold a new React project with Vite and TypeScript.
+- [ ] Install and configure Tailwind CSS.
+- [ ] Add ESLint and Prettier configuration files.
+
+## 2. Core Layout
+- [ ] Implement a responsive grid layout using Flexbox and CSS Grid.
+- [ ] Create a header component and a sidebar navigation component.
+- [ ] Add a footer showing application metadata.
+- [ ] Support both light and dark themes.
+
+## 3. Authentication Flow
+- [ ] Build login and registration forms with validation.
+- [ ] Implement JWT-based authentication and token refresh.
+- [ ] Add password reset and email verification pages.
+
+## 4. Dashboard & Reports
+- [ ] Create a dashboard view summarizing resource usage and costs.
+- [ ] Integrate interactive charts (e.g., Chart.js or D3.js).
+- [ ] Implement filters for user, project, and date range.
+- [ ] Build tables for detailed cost breakdowns with accessibility in mind.
+
+## 5. Settings & User Management
+- [ ] Develop profile management pages for updating user information.
+- [ ] Enforce role-based access for admin pages.
+- [ ] Provide theme customization options (color palette, layout density).
+
+## 6. Accessibility & UX Enhancements
+- [ ] Ensure keyboard navigation for all interactive elements.
+- [ ] Add ARIA attributes for screen readers.
+- [ ] Implement subtle animations (e.g., fade transitions).
+
+## 7. Testing & Optimization
+- [ ] Write unit tests with Jest and component tests with React Testing Library.
+- [ ] Configure Cypress for end-to-end tests.
+- [ ] Optimize assets with code splitting and lazy loading.
+
+## 8. Deployment
+- [ ] Create production build scripts using Vite.
+- [ ] Provide Docker configuration for the frontend.
+- [ ] Set up continuous deployment with GitHub Actions.
+


### PR DESCRIPTION
## Summary
- create a checklist of coding tasks derived from the existing frontend task list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686040fd44c48324bad25b6c56b0e41d