### PR TITLE
Add live development workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,5 +5,5 @@ Thank you for wanting to contribute! Please follow these basic guidelines:
 1. Fork the repository and create your branch from `main`.
 2. If you've added code, please ensure it is covered by tests.
 3. Update the documentation when adding features.
-4. Make sure the test suite passes (`make test`).
+4. Make sure the test suite passes (`make check`).
 5. Create a pull request and describe your changes.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 DIST=dist
+COCKPIT_DIR=$(HOME)/.local/share/cockpit
+COCKPIT_TARGET=$(COCKPIT_DIR)/slurmcostmanager
 
 all: build
 
@@ -7,7 +9,29 @@ build:
 	cp -r src/* $(DIST)/
 	cp manifest.json $(DIST)/
 
+
 clean:
 	rm -rf $(DIST)
 
-.PHONY: all build clean
+devel-install: build
+	mkdir -p $(COCKPIT_DIR)
+	ln -sfn $(abspath $(DIST)) $(COCKPIT_TARGET)
+
+devel-uninstall:
+	@if [ -L $(COCKPIT_TARGET) ]; then \
+	rm $(COCKPIT_TARGET); \
+	else \
+		echo "No symlink to remove at $(COCKPIT_TARGET)"; \
+	fi
+
+watch:
+	@command -v inotifywait >/dev/null || { echo "inotifywait not found"; exit 1; }
+	@echo "Watching src/ for changes..."
+		@while inotifywait -e modify,create,delete -r src/; do \
+			make devel-install; \
+	done
+
+check:
+	./test/check-application
+
+.PHONY: all build clean devel-install devel-uninstall watch check

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SlurmCostManager/
 │   ├── slurmcostmanager.html              # HTML entrypoint loaded inside Cockpit
 │   └── slurmcostmanager.js                # Frontend plugin logic, using cockpit APIs
 ├── manifest.json                          # Cockpit module metadata, menu registration
-├── Makefile                               # Build, install, devel-install, watch, check targets
+├── Makefile                               # Build, devel-install, devel-uninstall, watch, check targets
 ├── dist/                                  # Bundled output directory for Cockpit to load
 ├── test/                                  # Integration tests using Cockpit test harness
 │   └── check-application                  # Python-based browser tests via DevTools protocol
@@ -34,10 +34,18 @@ SlurmCostManager/
 
 Recommend using the **Cockpit Starter Kit** workflow to scaffold and build your plugin:
 
-- Use `make devel-install` to symlink your dist output into `~/.local/share/cockpit/` for live development.  
-- Run `make build` or `make` to compile and prepare for release.  
+- Use `make devel-install` to symlink your dist output into `~/.local/share/cockpit/` for live development.
+- Use `make devel-uninstall` when finished to remove the development symlink.
+- Optionally run `make watch` to rebuild and reinstall whenever files in `src/` change (requires `inotifywait`).
+- Run `make build` or `make` to compile and prepare for release.
 - Use `make check` to run integration tests via Cockpit's VM-based test system.
 Cockpit’s `manifest.json` registers your tool under the main menu. Your UI files will live in `src/`, built via webpack into `dist/`.
+
+### Manual verification
+
+1. Run `make devel-install` and confirm that `~/.local/share/cockpit/slurmcostmanager` is a symlink.
+2. Open Cockpit at `https://<host>:9090` and verify the **SlurmCostManager** entry appears.
+3. When done developing, execute `make devel-uninstall` to remove the symlink.
 
 ## 🌐 Usage
 


### PR DESCRIPTION
## Summary
- add devel-install/uninstall/watch/check targets to Makefile
- document the new workflow in the README
- update contribution instructions for `make check`

## Testing
- `make check`
- `make devel-install`
- `make devel-uninstall`


------
https://chatgpt.com/codex/tasks/task_e_688c41493a808324aaa12175f5267643