### PR TITLE
Add rate-based charge calculator

### DIFF
--- a/src/cost-calculator.js
+++ b/src/cost-calculator.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/**
+ * Calculate charges from usage records applying rates and overrides.
+ *
+ * @param {Array} usage - Array of {account, date, core_hours}
+ * @param {Object} config - Configuration with defaultRate, historicalRates, overrides
+ * @returns {Object} charges grouped by month then account
+ */
+function calculateCharges(usage, config = {}) {
+  const defaultRate = typeof config.defaultRate === 'number' ? config.defaultRate : 0.01;
+  const historical = config.historicalRates || {};
+  const overrides = config.overrides || {};
+
+  const charges = {};
+
+  for (const record of usage) {
+    if (!record || typeof record.core_hours !== 'number') continue;
+    const account = record.account || 'unknown';
+    const month = (record.date || '').slice(0, 7); // YYYY-MM
+    const ovr = overrides[account] || {};
+    const rate = typeof ovr.rate === 'number'
+      ? ovr.rate
+      : (typeof historical[month] === 'number' ? historical[month] : defaultRate);
+    let cost = record.core_hours * rate;
+    if (typeof ovr.discount === 'number' && ovr.discount > 0 && ovr.discount < 1) {
+      cost = cost * (1 - ovr.discount);
+    }
+
+    if (!charges[month]) charges[month] = {};
+    if (!charges[month][account]) charges[month][account] = { core_hours: 0, cost: 0 };
+    charges[month][account].core_hours += record.core_hours;
+    charges[month][account].cost += cost;
+  }
+
+  return charges;
+}
+
+module.exports = {
+  calculateCharges,
+};

--- a/src/rates.json
+++ b/src/rates.json
@@ -1,0 +1,5 @@
+{
+  "defaultRate": 0.01,
+  "historicalRates": {},
+  "overrides": {}
+}

--- a/test/check-application
+++ b/test/check-application
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Placeholder test script
-echo "Running SlurmCostManager tests..."
-# In a full implementation, Cockpit's integration tests would be invoked here.
-exit 0
+# Run unit tests for SlurmCostManager
+set -e
+
+# unit tests
+node test/unit/calculator.test.js

--- a/test/unit/calculator.test.js
+++ b/test/unit/calculator.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const { calculateCharges } = require('../../src/cost-calculator');
+
+function testDefaultRate() {
+  const usage = [
+    { account: 'acct1', date: '2024-06-01', core_hours: 100 },
+    { account: 'acct1', date: '2024-06-02', core_hours: 50 }
+  ];
+  const charges = calculateCharges(usage, { defaultRate: 0.01 });
+  assert.strictEqual(charges['2024-06'].acct1.cost, 150 * 0.01);
+}
+
+function testHistoricalRate() {
+  const usage = [
+    { account: 'acct1', date: '2024-07-01', core_hours: 100 }
+  ];
+  const charges = calculateCharges(usage, { defaultRate: 0.01, historicalRates: { '2024-07': 0.02 } });
+  assert.strictEqual(charges['2024-07'].acct1.cost, 100 * 0.02);
+}
+
+function testAccountOverride() {
+  const usage = [
+    { account: 'acct2', date: '2024-06-01', core_hours: 200 }
+  ];
+  const charges = calculateCharges(usage, { defaultRate: 0.01, overrides: { acct2: { rate: 0.005 } } });
+  assert.strictEqual(charges['2024-06'].acct2.cost, 200 * 0.005);
+}
+
+function testDiscount() {
+  const usage = [
+    { account: 'acct3', date: '2024-06-01', core_hours: 100 }
+  ];
+  const charges = calculateCharges(usage, { defaultRate: 0.01, overrides: { acct3: { discount: 0.5 } } });
+  assert.strictEqual(charges['2024-06'].acct3.cost, 100 * 0.01 * 0.5);
+}
+
+function run() {
+  testDefaultRate();
+  testHistoricalRate();
+  testAccountOverride();
+  testDiscount();
+  console.log('All calculator tests passed.');
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = run;


### PR DESCRIPTION
## Summary
- implement charge calculator to apply core-hour rates
- provide default rate configuration
- add unit tests covering overrides and historical rates
- update test script to run node tests

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_688d307fa3c08324964e74b0cc7a2839