### PR TITLE
Add schema export helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ python3 src/slurmdb.py --start 2024-06-01 --end 2024-06-30 --output billing.json
 The resulting `billing.json` file mirrors the structure expected by the
 frontend so it can be dropped in place of `mock-billing.json`.
 
+### Inspecting the database schema
+
+If you need to see which tables and columns are present in your Slurm
+accounting database, run the helper script `src/slurm_schema.py`.  It
+uses the same connection options as `slurmdb.py` and writes a JSON
+mapping of tables to their columns.
+
+```bash
+python3 src/slurm_schema.py --output schema.json
+# python3 src/slurm_schema.py --conf /path/to/slurmdbd.conf --cluster localcluster
+```
+
+The resulting `schema.json` file can be compared with the list of
+tables and columns from your deployment.
+
 ## 📝 Development Notes
 
 - Your UI components can access system files or commands using `cockpit.file()` and other Cockpit APIs.

--- a/src/slurm_schema.py
+++ b/src/slurm_schema.py
@@ -1,0 +1,46 @@
+import json
+import argparse
+
+try:
+    import pymysql
+except ImportError:
+    pymysql = None
+
+from slurmdb import SlurmDB
+
+
+def extract_schema(db: SlurmDB):
+    """Return mapping of table names to column lists."""
+    db.connect()
+    schema = {}
+    with db._conn.cursor() as cur:
+        cur.execute("SHOW TABLES")
+        table_key = f"Tables_in_{db.database}"
+        tables = [row[table_key] for row in cur.fetchall()]
+        for table in tables:
+            cur.execute(f"SHOW COLUMNS FROM {table}")
+            schema[table] = [row['Field'] for row in cur.fetchall()]
+    return schema
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export SlurmDB schema as JSON")
+    parser.add_argument('--output', default='slurm_schema.json', help='output file')
+    parser.add_argument('--conf', help='path to slurmdbd.conf')
+    parser.add_argument('--cluster', help='cluster name (table prefix)')
+    parser.add_argument('--slurm-conf', dest='slurm_conf', help='path to slurm.conf')
+    args = parser.parse_args()
+
+    if pymysql is None:
+        raise RuntimeError('pymysql is required but not installed')
+
+    db = SlurmDB(config_file=args.conf, cluster=args.cluster, slurm_conf=args.slurm_conf)
+    schema = extract_schema(db)
+
+    with open(args.output, 'w') as fh:
+        json.dump(schema, fh, indent=2)
+    print(f"Wrote {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -132,7 +132,7 @@ class SlurmDB:
         with self._conn.cursor() as cur:
             table = f"{self.cluster}_job_table" if self.cluster else "job_table"
             query = (
-                f"SELECT account, time_start, time_end, tres_alloc, req_mem "
+                f"SELECT account, time_start, time_end, tres_alloc, mem_req "
                 f"FROM {table} WHERE time_start >= %s AND time_end <= %s"
             )
             cur.execute(query, (start_time, end_time))
@@ -154,7 +154,7 @@ class SlurmDB:
             account = row.get('account') or 'unknown'
             cpus = self._parse_tres(row.get('tres_alloc'), 'cpu')
             nodes = self._parse_tres(row.get('tres_alloc'), 'node')
-            mem_gb = self._parse_mem(row.get('req_mem'))
+            mem_gb = self._parse_mem(row.get('mem_req'))
 
             month_entry = agg.setdefault(month, {})
             acct_entry = month_entry.setdefault(


### PR DESCRIPTION
## Summary
- add `slurm_schema.py` helper script to export SlurmDB schema
- document the helper in the README
- fix memory column name in job usage query

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_688d4c101e28832481c875a5c6bab53b