### PR TITLE
Validate and sanitize inputs

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -4,3 +4,4 @@ set -e
 
 # unit tests
 node test/unit/calculator.test.js
+PYTHONPATH=src python test/unit/slurmdb_validation.test.py

--- a/test/unit/calculator.test.js
+++ b/test/unit/calculator.test.js
@@ -34,11 +34,20 @@ function testDiscount() {
   assert.strictEqual(charges['2024-06'].acct3.cost, 100 * 0.01 * 0.5);
 }
 
+function testInvalidUsageIgnored() {
+  const usage = [
+    { account: 'acct4', date: '2024-06-01', core_hours: 'not-a-number' }
+  ];
+  const charges = calculateCharges(usage, { defaultRate: 0.01 });
+  assert.deepStrictEqual(charges, {});
+}
+
 function run() {
   testDefaultRate();
   testHistoricalRate();
   testAccountOverride();
   testDiscount();
+  testInvalidUsageIgnored();
   console.log('All calculator tests passed.');
 }
 

--- a/test/unit/slurmdb_validation.test.py
+++ b/test/unit/slurmdb_validation.test.py
@@ -1,0 +1,23 @@
+import unittest
+from slurmdb import SlurmDB
+
+class SlurmDBValidationTests(unittest.TestCase):
+    def test_invalid_cluster_rejected(self):
+        with self.assertRaises(ValueError):
+            SlurmDB(cluster="bad;DROP TABLE")
+
+    def test_invalid_port_rejected(self):
+        with self.assertRaises(ValueError):
+            SlurmDB(port=70000)
+
+    def test_valid_config_allowed(self):
+        db = SlurmDB(host="localhost", port=3306, user="slurm", password="", database="slurm_acct_db", cluster="cluster1")
+        self.assertEqual(db.cluster, "cluster1")
+
+    def test_invalid_time_format(self):
+        db = SlurmDB()
+        with self.assertRaises(ValueError):
+            db._validate_time("not-a-date", "start_time")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate SlurmDB configuration values and query parameters
- add tests for malicious config and usage records

## Testing
- `./test/check-application`


------
https://chatgpt.com/codex/tasks/task_e_688e9f105f2483249199935ceafd95ac