### PR TITLE
Handle slurmdb script path dynamically

### DIFF
--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -9,12 +9,10 @@ function useBillingData() {
     async function load() {
       try {
         let json;
-        if (window.cockpit && window.cockpit.spawn) {
+        if (window.cockpit && window.cockpit.script) {
           const end = new Date();
           const start = new Date(end.getFullYear(), end.getMonth(), 1);
           const args = [
-            'python3',
-            '/usr/share/cockpit/slurmcostmanager/slurmdb.py',
             '--start',
             start.toISOString().slice(0, 10),
             '--end',
@@ -22,7 +20,11 @@ function useBillingData() {
             '--output',
             '-',
           ];
-          const output = await window.cockpit.spawn(args, { err: 'message' });
+          const output = await window.cockpit.script(
+            'slurmdb.py',
+            args,
+            { err: 'message' }
+          );
           json = JSON.parse(output);
         } else {
           const resp = await fetch('billing.json');

--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import re
 import json


### PR DESCRIPTION
## Summary
- run slurmdb.py via `cockpit.script` instead of a hard-coded path
- add Python shebang to slurmdb.py

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689036f730b88324b52cfec141cf346d