### PR TITLE
Add RPM/DEB packaging targets and metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,63 @@
 DIST=dist
 COCKPIT_DIR=$(HOME)/.local/share/cockpit
 COCKPIT_TARGET=$(COCKPIT_DIR)/slurmcostmanager
+VERSION:=$(shell jq -r .version manifest.json)
+DATE:=$(shell date +%Y-%m-%d)
+RPMBUILD?=rpmbuild
+.RECIPEPREFIX := >
 
 all: build
 
-build:
-	mkdir -p $(DIST)
-	cp -r src/* $(DIST)/
-	cp manifest.json $(DIST)/
+org.cockpit_project.slurmcostmanager.metainfo.xml: org.cockpit_project.slurmcostmanager.metainfo.xml.in manifest.json
+>sed -e "s/@VERSION@/$(VERSION)/" -e "s/@DATE@/$(DATE)/" $< > $@
 
+build: org.cockpit_project.slurmcostmanager.metainfo.xml
+>mkdir -p $(DIST)
+>cp -r src/* $(DIST)/
+>cp manifest.json $(DIST)/
+>cp org.cockpit_project.slurmcostmanager.metainfo.xml $(DIST)/
 
 clean:
-	rm -rf $(DIST)
+>rm -rf $(DIST) rpmbuild debbuild slurmcostmanager-*.tar.gz slurmcostmanager_*.deb org.cockpit_project.slurmcostmanager.metainfo.xml
 
 devel-install: build
-	mkdir -p $(COCKPIT_DIR)
-	ln -sfn $(abspath $(DIST)) $(COCKPIT_TARGET)
+>mkdir -p $(COCKPIT_DIR)
+>ln -sfn $(abspath $(DIST)) $(COCKPIT_TARGET)
 
 devel-uninstall:
-	@if [ -L $(COCKPIT_TARGET) ]; then \
-	rm $(COCKPIT_TARGET); \
-	else \
-		echo "No symlink to remove at $(COCKPIT_TARGET)"; \
-	fi
+>@if [ -L $(COCKPIT_TARGET) ]; then \
+>rm $(COCKPIT_TARGET); \
+>else \
+>echo "No symlink to remove at $(COCKPIT_TARGET)"; \
+>fi
 
 watch:
-	@command -v inotifywait >/dev/null || { echo "inotifywait not found"; exit 1; }
-	@echo "Watching src/ for changes..."
-		@while inotifywait -e modify,create,delete -r src/; do \
-			make devel-install; \
-	done
+>@command -v inotifywait >/dev/null || { echo "inotifywait not found"; exit 1; }
+>@echo "Watching src/ for changes..."
+>@while inotifywait -e modify,create,delete -r src/; do \
+>make devel-install; \
+>done
+
+package: build
+>tar -czf slurmcostmanager-$(VERSION).tar.gz -C $(DIST) . --transform 's,^,slurmcostmanager-$(VERSION)/,'
+
+rpm: package
+>rm -rf rpmbuild
+>mkdir -p rpmbuild/BUILD rpmbuild/RPMS rpmbuild/SOURCES rpmbuild/SPECS rpmbuild/SRPMS
+>cp slurmcostmanager-$(VERSION).tar.gz rpmbuild/SOURCES/
+>printf 'Summary: Slurm Cost Manager\nName: slurmcostmanager\nVersion: $(VERSION)\nRelease: 1\nLicense: MIT\nSource0: %%{name}-%%{version}.tar.gz\nBuildArch: noarch\nRequires: cockpit\n%%description\nSlurm Cost Manager Cockpit plugin\n%%prep\n%%setup -q\n%%build\n%%install\nmkdir -p %%{buildroot}/usr/share/cockpit/slurmcostmanager\ncp -a * %%{buildroot}/usr/share/cockpit/slurmcostmanager/\n%%files\n/usr/share/cockpit/slurmcostmanager\n' > rpmbuild/SPECS/slurmcostmanager.spec
+>$(RPMBUILD) --define "_topdir $(PWD)/rpmbuild" -bb rpmbuild/SPECS/slurmcostmanager.spec
+
+deb: package
+>rm -rf debbuild
+>mkdir -p debbuild/usr/share/cockpit/slurmcostmanager
+>cp -a $(DIST)/* debbuild/usr/share/cockpit/slurmcostmanager/
+>mkdir -p debbuild/DEBIAN
+>echo "Package: slurmcostmanager\nVersion: $(VERSION)\nSection: admin\nPriority: optional\nArchitecture: all\nMaintainer: Unknown\nDepends: cockpit\nDescription: Slurm Cost Manager Cockpit plugin" > debbuild/DEBIAN/control
+>dpkg-deb --build debbuild slurmcostmanager_$(VERSION)_all.deb
+>rm -rf debbuild
 
 check:
-	./test/check-application
+>./test/check-application
 
-.PHONY: all build clean devel-install devel-uninstall watch check
+.PHONY: all build clean devel-install devel-uninstall watch package rpm deb check

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ Recommend using the **Cockpit Starter Kit** workflow to scaffold and build your 
 - Use `make check` to run integration tests via Cockpit's VM-based test system.
 Cockpit’s `manifest.json` registers your tool under the main menu. Your UI files will live in `src/`, built via webpack into `dist/`.
 
+## 📦 Packaging
+
+Build RPM and DEB packages for distribution:
+
+```bash
+make rpm  # writes an RPM to rpmbuild/RPMS/
+make deb  # creates slurmcostmanager_<version>_all.deb
+```
+
+Both targets generate `org.cockpit_project.slurmcostmanager.metainfo.xml` and bundle the existing `manifest.json` so the packages can be installed on RPM or DEB based systems.
+
 ### Manual verification
 
 1. Run `make devel-install` and confirm that `~/.local/share/cockpit/slurmcostmanager` is a symlink.

--- a/org.cockpit_project.slurmcostmanager.metainfo.xml.in
+++ b/org.cockpit_project.slurmcostmanager.metainfo.xml.in
@@ -6,5 +6,5 @@
   <url type="homepage">https://github.com/NessieCanCode/SlurmCostManager</url>
   <metadata_license>MIT</metadata_license>
   <project_license>MIT</project_license>
-  <release version="1.0.0" date="2025-08-04"/>
+  <release version="@VERSION@" date="@DATE@"/>
 </component>


### PR DESCRIPTION
## Summary
- add Makefile targets for building, RPM/DEB packaging and local development
- generate metainfo XML from template and include in build
- document RPM and DEB packaging commands

## Testing
- `make check`
- `make rpm`
- `make deb`


------
https://chatgpt.com/codex/tasks/task_e_68903a95252083249d3ec410ab83c524