### PR TITLE
Add community guidelines and contribution templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-and-a.md
+++ b/.github/DISCUSSION_TEMPLATE/q-and-a.md
@@ -1,0 +1,10 @@
+---
+title: "Question"
+labels: []
+description: Ask a question about using the project
+category: Q&A
+---
+
+## Question
+
+Ask your question here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+- OS: [e.g. Fedora 40]
+- SlurmCostManager version: [e.g. 1.0.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Support
+    url: https://github.com/cockpit-project/SlurmCostManager/discussions
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+Describe the big picture of your changes here.
+
+## Testing
+- [ ] `make check`
+
+## Checklist
+- [ ] Code follows project style guidelines
+- [ ] Tests added or updated
+- [ ] Documentation updated
+- [ ] Linked to related issues or discussions

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,6 @@
+# Support
+
+For questions, ideas, or general discussion about SlurmCostManager, please use
+[GitHub Discussions](https://github.com/cockpit-project/SlurmCostManager/discussions).
+
+Bug reports and feature requests should use the appropriate issue templates.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+slurmcostmanager-maintainers@example.com. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,38 @@
 # Contributing to SlurmCostManager
 
-Thank you for wanting to contribute! Please follow these basic guidelines:
+We welcome contributions of all kinds. Please take a moment to review these
+guidelines to help us keep the process smooth for everyone.
 
-1. Fork the repository and create your branch from `main`.
-2. If you've added code, please ensure it is covered by tests.
-3. Update the documentation when adding features.
-4. Make sure the test suite passes (`make check`).
-5. Ensure all CI status checks (linting, tests, security scans) pass before requesting a merge.
-6. Create a pull request and describe your changes.
+## Community Support
+
+Questions about using SlurmCostManager? Start a thread in
+[GitHub Discussions](https://github.com/cockpit-project/SlurmCostManager/discussions).
+See [SUPPORT.md](.github/SUPPORT.md) for more ways to get in touch.
+
+## Code of Conduct
+
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Reporting Bugs and Requesting Features
+
+Before filing an issue, search existing [issues](https://github.com/cockpit-project/SlurmCostManager/issues)
+and [discussions](https://github.com/cockpit-project/SlurmCostManager/discussions) to avoid duplicates.
+Use the provided templates when opening a bug report or feature request.
+
+## Development Workflow
+
+1. Fork the repository and create a topic branch off `main`.
+2. Make your changes, including tests and documentation when appropriate.
+3. Run `make check` and ensure all tests pass.
+4. Commit with clear messages that describe your changes.
+5. Submit a pull request using the template provided.
+
+## Review & Approval
+
+* CI checks must pass before a review will be taken.
+* Every pull request requires approval from at least one maintainer.
+* Reviewers may request additional changes or tests; please address all comments.
+* Once approved and all checks pass, a maintainer will merge your pull request.
+
+Thank you for helping to improve SlurmCostManager!


### PR DESCRIPTION
## Summary
- expand contributing guide with community support and review process
- add code of conduct and support channels
- provide issue, PR, and discussion templates

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6890c986a1988324af78d764b49afbe4