### PR TITLE
add release workflow and changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.2.3)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Create tag
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git tag v${{ github.event.inputs.version }}
+          git push origin v${{ github.event.inputs.version }}
+      - name: Build
+        run: make build
+      - name: Package
+        run: |
+          make rpm
+          make deb
+      - name: Publish Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          name: v${{ github.event.inputs.version }}
+          files: |
+            dist/**/*
+            rpmbuild/RPMS/**/*.rpm
+            slurmcostmanager_*.deb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Placeholder for upcoming changes.
+
+## [1.0.0] - 2025-08-04
+### Added
+- Initial release of SlurmCostManager.
+

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ Both targets generate `org.cockpit_project.slurmcostmanager.metainfo.xml` and bu
 2. Open Cockpit at `https://<host>:9090` and verify the **SlurmCostManager** entry appears.
 3. When done developing, execute `make devel-uninstall` to remove the symlink.
 
+## 🧭 Versioning and Releases
+
+The project follows [Semantic Versioning](https://semver.org/). All notable changes are recorded in [CHANGELOG.md](CHANGELOG.md) and upgrade notes live in [UPGRADING.md](UPGRADING.md).
+
+To cut a new release:
+
+1. Bump the version in `manifest.json` and update the changelog and upgrade guide.
+2. Trigger the **Release** workflow from the GitHub Actions tab and supply the new version number.
+
+The workflow tags the repository, builds packages, and publishes artifacts to GitHub Releases automatically.
+
 ## 🌐 Usage
 
 1. On a Linux host with **Cockpit** installed (e.g. CentOS, Fedora, Debian compatible).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,9 @@
+# Upgrade Guide
+
+This document outlines steps required to upgrade between SlurmCostManager versions.
+
+## 1.0.0
+- Initial public release.
+- If upgrading from pre-release versions, rebuild and reinstall the plugin using `make build` followed by `make devel-install`.
+- Review the [CHANGELOG](CHANGELOG.md) for user-visible changes before upgrading.
+


### PR DESCRIPTION
## Summary
- establish changelog and upgrade guide following semantic versioning
- document release workflow and upgrade guidance in README
- automate tagging, build and release artifacts via GitHub Actions

## Testing
- `flake8 src test` *(fails: line too long and E3xx style errors)*
- `PYTHONPATH=src python test/unit/slurmdb_validation.test.py`
- `node test/unit/calculator.test.js`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6890c9731dcc8324a5c9feece81067a2