### PR TITLE
Refocus billing UI on core hours

### DIFF
--- a/src/slurmcostmanager.css
+++ b/src/slurmcostmanager.css
@@ -93,6 +93,18 @@ nav button:hover {
   padding: 0.25em 0.5em;
 }
 
+.jobs-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5em;
+}
+
+.jobs-table th,
+.jobs-table td {
+  border: 1px solid #ccc;
+  padding: 0.25em 0.5em;
+}
+
 .chart-container {
   position: relative;
   height: 300px;

--- a/test/unit/billing_summary.test.py
+++ b/test/unit/billing_summary.test.py
@@ -9,16 +9,18 @@ class BillingSummaryTests(unittest.TestCase):
             '2023-10': {
                 'acct': {
                     'core_hours': 10.0,
-                    'instance_hours': 5.0,
-                    'gb_month': 1.0,
                     'users': {
-                        'user1': {'core_hours': 10.0},
+                        'user1': {'core_hours': 10.0, 'jobs': {}}
                     },
                 }
             }
         }
         invoices = [{'file': 'inv1.pdf', 'date': '2023-10-01'}]
-        with mock.patch.object(SlurmDB, 'aggregate_usage', return_value=usage):
+        with mock.patch.object(
+            SlurmDB,
+            'aggregate_usage',
+            return_value=(usage, {'daily': {}, 'monthly': {}, 'yearly': {}}),
+        ):
             with mock.patch.object(SlurmDB, 'fetch_invoices', return_value=invoices):
                 db = SlurmDB()
                 summary = db.export_summary('2023-10-01', '2023-10-31')

--- a/test/unit/slurmdb_validation.test.py
+++ b/test/unit/slurmdb_validation.test.py
@@ -31,10 +31,10 @@ class SlurmDBValidationTests(unittest.TestCase):
                 'mem_req': '1024M',
             }
         ]
-        agg = db.aggregate_usage(0, 3600)
+        agg, totals = db.aggregate_usage(0, 3600)
         self.assertIn('1970-01', agg)
         self.assertAlmostEqual(agg['1970-01']['acct']['core_hours'], 2.0)
-        self.assertAlmostEqual(agg['1970-01']['acct']['instance_hours'], 1.0)
+        self.assertAlmostEqual(totals['daily']['1970-01-01'], 2.0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- focus on core-hour metrics and provide daily/monthly/yearly totals
- drill down from accounts to users and jobs in details view
- allow invoice download directly from summary

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68922650b31c8324a4bbe0bd22e0e2c6