### PR TITLE
Convert date strings to timestamps for DB queries

### DIFF
--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -95,7 +95,10 @@ class SlurmDB:
         if isinstance(value, (int, float)):
             return int(value)
         if isinstance(value, str) and self._DATE_RE.match(value):
-            return value
+            dt = datetime.fromisoformat(value)
+            if name in ("end_time", "end_date"):
+                dt = dt.replace(hour=23, minute=59, second=59)
+            return int(dt.timestamp())
         raise ValueError(f"Invalid {name} format")
 
     def _to_datetime(self, value):

--- a/test/unit/slurmdb_validation.test.py
+++ b/test/unit/slurmdb_validation.test.py
@@ -19,6 +19,13 @@ class SlurmDBValidationTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             db._validate_time("not-a-date", "start_time")
 
+    def test_validate_time_converts_dates(self):
+        db = SlurmDB()
+        start = db._validate_time("1970-01-02", "start_time")
+        end = db._validate_time("1970-01-02", "end_time")
+        self.assertEqual(start, 86400)
+        self.assertEqual(end, 172799)
+
     def test_aggregate_usage_handles_int_timestamps(self):
         db = SlurmDB()
         db.fetch_usage_records = lambda start, end: [


### PR DESCRIPTION
## Summary
- parse YYYY-MM-DD inputs into epoch timestamps for database queries
- include full day for end dates and add regression tests

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6892559b31d4832498d1ec9804a3fb30