### PR TITLE
Fix date string handling in Slurm usage queries

### DIFF
--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -95,7 +95,13 @@ class SlurmDB:
         if isinstance(value, (int, float)):
             return int(value)
         if isinstance(value, str) and self._DATE_RE.match(value):
-            return value
+            # Convert YYYY-MM-DD strings to a UNIX timestamp so comparisons
+            # against numeric time_start/time_end columns work correctly.
+            try:
+                dt = datetime.fromisoformat(value)
+                return int(dt.timestamp())
+            except ValueError:
+                pass
         raise ValueError(f"Invalid {name} format")
 
     def _to_datetime(self, value):

--- a/test/unit/slurmdb_validation.test.py
+++ b/test/unit/slurmdb_validation.test.py
@@ -19,6 +19,12 @@ class SlurmDBValidationTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             db._validate_time("not-a-date", "start_time")
 
+    def test_validate_time_parses_date_strings(self):
+        db = SlurmDB()
+        ts = db._validate_time("1970-01-02", "start_time")
+        # 1970-01-02 is 86400 seconds from the epoch
+        self.assertEqual(ts, 86400)
+
     def test_aggregate_usage_handles_int_timestamps(self):
         db = SlurmDB()
         db.fetch_usage_records = lambda start, end: [


### PR DESCRIPTION
## Summary
- convert YYYY-MM-DD strings to Unix timestamps for proper time range filtering
- add unit test for date string conversion

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6892559b31d4832498d1ec9804a3fb30