### PR TITLE
Handle missing CPU TRES by using cpus_alloc

### DIFF
--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -181,7 +181,7 @@ class SlurmDB:
             assoc_table = f"{self.cluster}_assoc_table" if self.cluster else "assoc_table"
             query = (
                 f"SELECT j.id_job AS jobid, j.account, a.user AS user_name, j.time_start, j.time_end, "
-                f"j.tres_alloc FROM {job_table} AS j "
+                f"j.tres_alloc, j.cpus_alloc FROM {job_table} AS j "
                 f"LEFT JOIN {assoc_table} AS a ON j.id_assoc = a.id_assoc "
                 f"WHERE j.time_start >= %s AND j.time_end <= %s"
             )
@@ -204,6 +204,11 @@ class SlurmDB:
             user = row.get('user_name') or 'unknown'
             job = str(row.get('jobid') or 'unknown')
             cpus = self._parse_tres(row.get('tres_alloc'), 'cpu')
+            if not cpus:
+                try:
+                    cpus = float(row.get('cpus_alloc') or 0)
+                except (TypeError, ValueError):
+                    cpus = 0.0
 
             totals['daily'][day] = totals['daily'].get(day, 0.0) + cpus * dur_hours
             totals['monthly'][month] = totals['monthly'].get(month, 0.0) + cpus * dur_hours

--- a/test/unit/slurmdb_validation.test.py
+++ b/test/unit/slurmdb_validation.test.py
@@ -42,5 +42,20 @@ class SlurmDBValidationTests(unittest.TestCase):
         self.assertAlmostEqual(agg['1970-01']['acct']['core_hours'], 2.0)
         self.assertAlmostEqual(totals['daily']['1970-01-01'], 2.0)
 
+    def test_cpus_alloc_fallback(self):
+        db = SlurmDB()
+        db.fetch_usage_records = lambda start, end: [
+            {
+                'account': 'acct',
+                'user_name': 'user',
+                'time_start': 0,
+                'time_end': 3600,
+                'tres_alloc': '',
+                'cpus_alloc': 2,
+            }
+        ]
+        agg, totals = db.aggregate_usage(0, 3600)
+        self.assertAlmostEqual(agg['1970-01']['acct']['core_hours'], 2.0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- include `cpus_alloc` in usage query
- fall back to `cpus_alloc` when `tres_alloc` lacks CPU info
- add unit test covering `cpus_alloc` fallback

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6892559b31d4832498d1ec9804a3fb30