### PR TITLE
Add settings page and branded invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository now includes a responsive Cockpit UI built with React.  The inte
 - **Detailed cost drill-downs** (core‑hours, instance‑hours, GB‑month) for per‑account transparency.
 - **Historical billing data** accessible from account inception for auditing and trend analysis.
 - **Organization-wide views** consolidating charges across all member Slurm accounts.
-- **Configurable rate table** with per-account overrides, editable from a dedicated Rates tab.
+- **Configurable settings** page to manage rates, business information, and invoice branding.
 
 
 ## 📁 Project Structure

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,10 @@
     "slurmcostmanager": {
       "path": "slurmcostmanager.html",
       "label": "Slurm Cost Manager"
+    },
+    "slurmcostmanager-config": {
+      "path": "config.html",
+      "label": "Slurm Cost Manager Settings"
     }
   }
 }

--- a/src/config.html
+++ b/src/config.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Slurm Cost Manager Settings</title>
+  <link rel="stylesheet" href="slurmcostmanager.css" />
+</head>
+<body>
+  <div id="config-root">Loading...</div>
+  <script src="../base1/cockpit.js"></script>
+  <script src="vendor/react.production.min.js"></script>
+  <script src="vendor/react-dom.production.min.js"></script>
+  <script src="slurmcostmanager.js"></script>
+</body>
+</html>

--- a/src/rates-schema.json
+++ b/src/rates-schema.json
@@ -38,6 +38,15 @@
         }
       },
       "additionalProperties": false
+    },
+    "businessInfo": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "address": { "type": "string" },
+        "logo": { "type": "string" }
+      },
+      "additionalProperties": false
     }
   },
   "required": ["defaultRate"],

--- a/src/rates.json
+++ b/src/rates.json
@@ -1,4 +1,9 @@
 {
+  "businessInfo": {
+    "name": "Your Company",
+    "address": "123 Business Rd\nCity, ST 00000",
+    "logo": ""
+  },
   "defaultRate": 0.02,
   "historicalRates": {
     "2024-01": 0.015

--- a/src/slurmcostmanager.css
+++ b/src/slurmcostmanager.css
@@ -126,6 +126,17 @@ nav button:hover {
   box-sizing: border-box;
 }
 
+.config-section label {
+  display: block;
+  margin-top: 0.5em;
+}
+
+.config-section input,
+.config-section textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 @media (max-width: 600px) {
   nav button {
     display: block;

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -111,12 +111,65 @@ function CoreHoursChart({ data, labelKey }) {
 }
 
 function Summary({ summary, details, daily, monthly, yearly }) {
-  function downloadInvoice() {
+  async function downloadInvoice() {
     const pdflib = window.jspdf;
     if (!pdflib || !pdflib.jsPDF) return;
+
+    let business = {};
+    try {
+      let text;
+      if (window.cockpit && window.cockpit.file) {
+        text = await window.cockpit.file(`${PLUGIN_BASE}/rates.json`).read();
+      } else {
+        const resp = await fetch('rates.json');
+        if (resp.ok) text = await resp.text();
+      }
+      if (text) {
+        const cfg = JSON.parse(text);
+        business = cfg.businessInfo || {};
+      }
+    } catch (e) {
+      console.error(e);
+    }
+
     const doc = new pdflib.jsPDF();
-    doc.text(`Invoice for ${summary.period}`, 10, 10);
-    let y = 20;
+    let y = 10;
+
+    if (business.logo) {
+      try {
+        const resp = await fetch(business.logo);
+        if (resp.ok) {
+          const blob = await resp.blob();
+          const dataUrl = await new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result);
+            reader.onerror = reject;
+            reader.readAsDataURL(blob);
+          });
+          doc.addImage(dataUrl, 'PNG', 10, y, 40, 20);
+          y += 25;
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    doc.setFontSize(16);
+    if (business.name) {
+      doc.text(business.name, 10, y);
+      y += 7;
+    }
+    doc.setFontSize(10);
+    if (business.address) {
+      business.address.split('\n').forEach(line => {
+        doc.text(line, 10, y);
+        y += 5;
+      });
+    }
+    y += 5;
+    doc.setFontSize(12);
+    doc.text(`Invoice for ${summary.period}`, 10, y);
+    y += 10;
     doc.text('Account', 10, y);
     doc.text('Core Hours', 80, y);
     doc.text('Cost ($)', 150, y);
@@ -340,9 +393,10 @@ function Details({ details }) {
 }
 
 
-function Rates({ onRatesUpdated }) {
+function ConfigEditor({ onConfigUpdated }) {
   const [config, setConfig] = useState(null);
   const [overrides, setOverrides] = useState([]);
+  const [business, setBusiness] = useState({ name: '', address: '', logo: '' });
   const [error, setError] = useState(null);
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState(null);
@@ -357,12 +411,17 @@ function Rates({ onRatesUpdated }) {
           text = await window.cockpit.file(`${baseDir}/rates.json`).read();
         } else {
           const resp = await fetch('rates.json');
-          if (!resp.ok) throw new Error('Failed to load rates');
+          if (!resp.ok) throw new Error('Failed to load config');
           text = await resp.text();
         }
         if (cancelled) return;
         const json = JSON.parse(text);
         setConfig({ defaultRate: json.defaultRate });
+        setBusiness({
+          name: (json.businessInfo && json.businessInfo.name) || '',
+          address: (json.businessInfo && json.businessInfo.address) || '',
+          logo: (json.businessInfo && json.businessInfo.logo) || ''
+        });
         const ovrs = json.overrides
           ? Object.entries(json.overrides).map(([account, cfg]) => ({
               account,
@@ -373,7 +432,7 @@ function Rates({ onRatesUpdated }) {
         setOverrides(ovrs);
       } catch (e) {
         console.error(e);
-        if (!cancelled) setError('Failed to load rates');
+        if (!cancelled) setError('Failed to load config');
       }
     }
     load();
@@ -402,7 +461,12 @@ function Rates({ onRatesUpdated }) {
       setError(null);
       setStatus(null);
       const json = {
-        defaultRate: parseFloat(config.defaultRate) || 0
+        defaultRate: parseFloat(config.defaultRate) || 0,
+        businessInfo: {
+          name: business.name,
+          address: business.address,
+          logo: business.logo
+        }
       };
       if (overrides.length) {
         json.overrides = {};
@@ -425,10 +489,10 @@ function Rates({ onRatesUpdated }) {
         });
       }
       setStatus('Saved');
-      if (onRatesUpdated) onRatesUpdated();
+      if (onConfigUpdated) onConfigUpdated();
     } catch (e) {
       console.error(e);
-      setError('Failed to save rates');
+      setError('Failed to save config');
     } finally {
       setSaving(false);
     }
@@ -436,27 +500,48 @@ function Rates({ onRatesUpdated }) {
 
   if (error) return React.createElement('p', { className: 'error' }, error);
   if (!config)
-    return React.createElement('p', null, 'Loading rate configuration...');
+    return React.createElement('p', null, 'Loading configuration...');
 
   return React.createElement(
     'div',
-    null,
-    React.createElement('h2', null, 'Rate Configuration'),
+    { className: 'config-section' },
+    React.createElement('h3', null, 'Business Information'),
     React.createElement(
-      'div',
+      'label',
       null,
-      React.createElement(
-        'label',
-        null,
-        'Default Rate ($/core-hour): ',
-        React.createElement('input', {
-          type: 'number',
-          step: '0.001',
-          value: config.defaultRate,
-          onChange: e =>
-            setConfig({ ...config, defaultRate: e.target.value })
-        })
-      )
+      'Name',
+      React.createElement('input', {
+        value: business.name,
+        onChange: e => setBusiness({ ...business, name: e.target.value })
+      })
+    ),
+    React.createElement(
+      'label',
+      null,
+      'Address',
+      React.createElement('textarea', {
+        value: business.address,
+        onChange: e => setBusiness({ ...business, address: e.target.value })
+      })
+    ),
+    React.createElement(
+      'label',
+      null,
+      'Logo Path',
+      React.createElement('input', {
+        value: business.logo,
+        onChange: e => setBusiness({ ...business, logo: e.target.value })
+      })
+    ),
+    React.createElement('h3', null, 'Default Rate'),
+    React.createElement(
+      'input',
+      {
+        type: 'number',
+        step: '0.001',
+        value: config.defaultRate,
+        onChange: e => setConfig({ ...config, defaultRate: e.target.value })
+      }
     ),
     React.createElement('h3', null, 'Account Overrides'),
     React.createElement(
@@ -538,7 +623,7 @@ function Rates({ onRatesUpdated }) {
 
 function App() {
   const [view, setView] = useState('summary');
-  const { data, error, reload } = useBillingData();
+  const { data, error } = useBillingData();
 
   return React.createElement(
     'div',
@@ -555,15 +640,10 @@ function App() {
         'button',
         { onClick: () => setView('details') },
         'Details'
-      ),
-      React.createElement(
-        'button',
-        { onClick: () => setView('rates') },
-        'Rates'
       )
     ),
-    view !== 'rates' && !data && !error && React.createElement('p', null, 'Loading...'),
-    view !== 'rates' && error && React.createElement('p', { className: 'error' }, 'Failed to load data'),
+    !data && !error && React.createElement('p', null, 'Loading...'),
+    error && React.createElement('p', { className: 'error' }, 'Failed to load data'),
     data &&
       view === 'summary' &&
       React.createElement(Summary, {
@@ -573,11 +653,17 @@ function App() {
         monthly: data.monthly,
         yearly: data.yearly
       }),
-    data && view === 'details' && React.createElement(Details, { details: data.details }),
-    view === 'rates' && React.createElement(Rates, { onRatesUpdated: reload })
+    data && view === 'details' && React.createElement(Details, { details: data.details })
   );
 }
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  React.createElement(React.StrictMode, null, React.createElement(App))
-);
+const configRoot = document.getElementById('config-root');
+if (configRoot) {
+  ReactDOM.createRoot(configRoot).render(
+    React.createElement(React.StrictMode, null, React.createElement(ConfigEditor))
+  );
+} else {
+  ReactDOM.createRoot(document.getElementById('root')).render(
+    React.createElement(React.StrictMode, null, React.createElement(App))
+  );
+}


### PR DESCRIPTION
## Summary
- add Cockpit settings page to configure rates and business information
- include business branding and optional logo in generated invoices
- remove placeholder logo asset from repository

## Testing
- `node test/unit/calculator.test.js`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68927e242ac88324a10ef24ca1efeb74