### PR TITLE
Add sidebar layout and branded invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository now includes a responsive Cockpit UI built with React.  The inte
 - **Detailed cost drill-downs** (core‑hours, instance‑hours, GB‑month) for per‑account transparency.
 - **Historical billing data** accessible from account inception for auditing and trend analysis.
 - **Organization-wide views** consolidating charges across all member Slurm accounts.
-- **Configurable rate table** with per-account overrides, editable from a dedicated Rates tab.
+- **Full-screen sidebar navigation** with an integrated settings dropdown to manage rates, business information, and invoice branding.
 
 
 ## 📁 Project Structure

--- a/src/rates-schema.json
+++ b/src/rates-schema.json
@@ -38,6 +38,15 @@
         }
       },
       "additionalProperties": false
+    },
+    "businessInfo": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "address": { "type": "string" },
+        "logo": { "type": "string" }
+      },
+      "additionalProperties": false
     }
   },
   "required": ["defaultRate"],

--- a/src/rates.json
+++ b/src/rates.json
@@ -1,4 +1,9 @@
 {
+  "businessInfo": {
+    "name": "Your Company",
+    "address": "123 Business Rd\nCity, ST 00000",
+    "logo": ""
+  },
   "defaultRate": 0.02,
   "historicalRates": {
     "2024-01": 0.015

--- a/src/slurmcostmanager.css
+++ b/src/slurmcostmanager.css
@@ -1,32 +1,46 @@
+html, body, #root {
+  height: 100%;
+  margin: 0;
+}
+
 body {
   font-family: sans-serif;
   margin: 0;
   padding: 0;
 }
 
-nav {
-  background: #333;
-  padding: 0.5em;
+.app {
   display: flex;
-  flex-wrap: wrap;
+  height: 100%;
 }
 
-nav button {
-  margin-right: 0.5em;
+.sidebar {
+  width: 200px;
+  background: #333;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  padding: 0.5em 0;
+}
+
+.sidebar button {
+  text-align: left;
   padding: 0.5em 1em;
   color: #fff;
-  background: #555;
+  background: none;
   border: none;
-  border-radius: 3px;
   cursor: pointer;
 }
 
-nav button:hover {
-  background: #777;
+.sidebar button:hover,
+.sidebar button.active {
+  background: #555;
 }
 
-.app {
+.content {
+  flex: 1;
   padding: 1em;
+  overflow: auto;
 }
 
 .table-container {
@@ -126,9 +140,34 @@ nav button:hover {
   box-sizing: border-box;
 }
 
-@media (max-width: 600px) {
-  nav button {
-    display: block;
-    margin: 0.5em 0;
-  }
+.config-section label {
+  display: block;
+  margin-top: 0.5em;
 }
+
+.config-section input,
+.config-section textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+
+.dropdown {
+  margin-top: auto;
+  position: relative;
+}
+
+.dropdown-menu {
+  position: absolute;
+  left: 100%;
+  top: 0;
+  background: #fff;
+  color: #000;
+  padding: 1em;
+  border: 1px solid #ccc;
+  z-index: 1000;
+  width: 300px;
+  max-height: 80vh;
+  overflow: auto;
+}
+


### PR DESCRIPTION
## Summary
- convert plugin to a full-screen Cockpit page with custom sidebar navigation
- move summary, details, and settings into sidebar and support configurable business branding in invoices
- remove placeholder logo asset

## Testing
- `node test/unit/calculator.test.js`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68927e242ac88324a10ef24ca1efeb74