### PR TITLE
Handle rate file errors explicitly

### DIFF
--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -2,6 +2,7 @@
 import os
 import re
 import json
+import logging
 import sys
 from datetime import datetime
 
@@ -288,8 +289,12 @@ class SlurmDB:
         try:
             with open(rates_path) as fh:
                 rates_cfg = json.load(fh)
-        except Exception:
+        except OSError as e:
+            logging.warning("Unable to read rates file %s: %s", rates_path, e)
             rates_cfg = {}
+        except json.JSONDecodeError as e:
+            logging.error("Failed to parse rates file %s: %s", rates_path, e)
+            raise
         default_rate = rates_cfg.get('defaultRate', 0.01)
         overrides = rates_cfg.get('overrides', {})
         historical = rates_cfg.get('historicalRates', {})


### PR DESCRIPTION
## Summary
- log and raise on invalid rate file JSON
- warn when rates file missing or unreadable

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6892c7555bf083249d3784ee5089d095