### PR TITLE
Add T and K unit support for Slurm memory parsing

### DIFF
--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -149,14 +149,19 @@ class SlurmDB:
     def _parse_mem(self, mem_str):
         if not mem_str:
             return 0.0
-        m = re.match(r"(\d+(?:\.\d+)?)([MG])", str(mem_str))
+        m = re.match(r"(\d+(?:\.\d+)?)([KMGTP])", str(mem_str))
         if not m:
             return 0.0
         val = float(m.group(1))
         unit = m.group(2).upper()
-        if unit == "M":
-            val /= 1024.0
-        return val  # GB
+        factors = {
+            "K": 1 / (1024.0 ** 2),  # KB to GB
+            "M": 1 / 1024.0,         # MB to GB
+            "G": 1.0,                # GB to GB
+            "T": 1024.0,             # TB to GB
+            "P": 1024.0 ** 2,        # PB to GB (future-proofing)
+        }
+        return val * factors.get(unit, 0.0)
 
     def _parse_tres(self, tres_str, key):
         if not tres_str:

--- a/test/unit/slurmdb_validation.test.py
+++ b/test/unit/slurmdb_validation.test.py
@@ -26,6 +26,13 @@ class SlurmDBValidationTests(unittest.TestCase):
         # 1970-01-02 is 86400 seconds from the epoch
         self.assertEqual(ts, 86400)
 
+    def test_parse_mem_converts_units(self):
+        db = SlurmDB()
+        self.assertEqual(db._parse_mem("1G"), 1.0)
+        self.assertEqual(db._parse_mem("1024M"), 1.0)
+        self.assertEqual(db._parse_mem("1T"), 1024.0)
+        self.assertAlmostEqual(db._parse_mem("1048576K"), 1.0)
+
     def test_aggregate_usage_handles_int_timestamps(self):
         db = SlurmDB()
         db.fetch_usage_records = lambda start, end: [


### PR DESCRIPTION
## Summary
- extend `_parse_mem` to accept K and T (plus future P) units, converting to GB
- add tests verifying memory parsing for kilobytes and terabytes

## Testing
- `./test/check-application`


------
https://chatgpt.com/codex/tasks/task_e_6892c7844f9483249fde75f88dfa63a6