### PR TITLE
Add context manager support and connection cleanup

### DIFF
--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -146,6 +146,26 @@ class SlurmDB:
                 if row and 'name' in row:
                     self.cluster = row['name']
 
+    def close(self):
+        """Close the database connection if open."""
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            finally:
+                self._conn = None
+
+    # Context manager support -------------------------------------------------
+    def __enter__(self):
+        """Connect to the database when entering a context."""
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """Ensure the connection is closed when leaving a context."""
+        self.close()
+        # Do not suppress exceptions
+        return False
+
     def _parse_mem(self, mem_str):
         if not mem_str:
             return 0.0

--- a/test/unit/slurmdb_validation.test.py
+++ b/test/unit/slurmdb_validation.test.py
@@ -58,6 +58,44 @@ class SlurmDBValidationTests(unittest.TestCase):
         agg, totals = db.aggregate_usage(0, 3600)
         self.assertAlmostEqual(agg['1970-01']['acct']['core_hours'], 2.0)
 
+    def test_close_closes_connection(self):
+        class FakeConn:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        db = SlurmDB()
+        fake = FakeConn()
+        db._conn = fake
+        db.close()
+        self.assertTrue(fake.closed)
+        self.assertIsNone(db._conn)
+
+    def test_context_manager_closes_connection(self):
+        class FakeConn:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        db = SlurmDB()
+
+        def fake_connect():
+            db._conn = FakeConn()
+
+        db.connect = fake_connect
+
+        with db as ctx:
+            self.assertIs(ctx, db)
+            self.assertIsNotNone(db._conn)
+            conn = db._conn
+
+        self.assertTrue(conn.closed)
+        self.assertIsNone(db._conn)
+
     def test_fetch_usage_records_uses_cpus_req_if_alloc_missing(self):
         schema = extract_schema_from_dump('test/test_db_dump.sql')
         job_cols = schema.get('localcluster_job_table', [])


### PR DESCRIPTION
## Summary
- add `SlurmDB.close()` to ensure pymysql connections are closed
- implement `__enter__`/`__exit__` for automatic cleanup in `with` blocks
- test connection cleanup and context manager usage

## Testing
- `test/check-application`


------
https://chatgpt.com/codex/tasks/task_e_6892c7b3699c8324a0fcc65337e55f60