### PR TITLE
Use UTC dates for billing period

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+__pycache__/

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -12,6 +12,15 @@ const PLUGIN_BASE =
     window.cockpit.manifest.path) ||
   '/usr/share/cockpit/slurmcostmanager';
 
+function getBillingPeriod(now = new Date()) {
+  const end = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+  const start = new Date(Date.UTC(now.getFullYear(), now.getMonth(), 1));
+  return {
+    start: start.toISOString().slice(0, 10),
+    end: end.toISOString().slice(0, 10)
+  };
+}
+
 function useBillingData() {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
@@ -20,15 +29,14 @@ function useBillingData() {
     try {
       let json;
       if (window.cockpit && window.cockpit.spawn) {
-        const end = new Date();
-        const start = new Date(end.getFullYear(), end.getMonth(), 1);
+        const { start, end } = getBillingPeriod();
         const args = [
           'python3',
           `${PLUGIN_BASE}/slurmdb.py`,
           '--start',
-          start.toISOString().slice(0, 10),
+          start,
           '--end',
-          end.toISOString().slice(0, 10),
+          end,
           '--output',
           '-',
         ];
@@ -605,6 +613,12 @@ function App() {
   );
 }
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  React.createElement(React.StrictMode, null, React.createElement(App))
-);
+if (typeof document !== 'undefined') {
+  ReactDOM.createRoot(document.getElementById('root')).render(
+    React.createElement(React.StrictMode, null, React.createElement(App))
+  );
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { getBillingPeriod };
+}

--- a/test/check-application
+++ b/test/check-application
@@ -4,6 +4,7 @@ set -e
 
 # unit tests
 node test/unit/calculator.test.js
+node test/unit/date_boundaries.test.js
 PYTHONPATH=src python test/unit/slurmdb_validation.test.py
 PYTHONPATH=src python test/unit/slurm_schema_dump.test.py
 PYTHONPATH=src python test/unit/billing_summary.test.py

--- a/test/unit/date_boundaries.test.js
+++ b/test/unit/date_boundaries.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const helper = path.join(__dirname, 'date_boundary_helper.js');
+
+function runWithTZ(tz, dateStr) {
+  return execFileSync(process.execPath, [helper, dateStr], {
+    env: { TZ: tz },
+    encoding: 'utf8'
+  }).trim();
+}
+
+function testPositiveTimezone() {
+  const output = runWithTZ('Pacific/Kiritimati', '2024-06-01T00:30:00');
+  assert.strictEqual(output, '2024-06-01,2024-06-01');
+}
+
+function testNegativeTimezone() {
+  const output = runWithTZ('Pacific/Honolulu', '2024-05-31T23:30:00');
+  assert.strictEqual(output, '2024-05-01,2024-05-31');
+}
+
+function run() {
+  testPositiveTimezone();
+  testNegativeTimezone();
+  console.log('All date boundary tests passed.');
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = run;

--- a/test/unit/date_boundary_helper.js
+++ b/test/unit/date_boundary_helper.js
@@ -1,0 +1,12 @@
+global.React = {
+  useState: () => {},
+  useEffect: () => {},
+  useRef: () => {},
+  useCallback: () => {}
+};
+
+const { getBillingPeriod } = require('../../src/slurmcostmanager.js');
+const dateStr = process.argv[2];
+const date = new Date(dateStr);
+const { start, end } = getBillingPeriod(date);
+console.log(`${start},${end}`);


### PR DESCRIPTION
## Summary
- Use UTC-based Date calculations to avoid timezone shifts when serializing billing periods
- Add tests ensuring correct start/end dates across timezones and include test in check script
- Ignore Python cache directories

## Testing
- `./test/check-application`

------
https://chatgpt.com/codex/tasks/task_e_6892c989a55483249e52a2b0f37ab7d1