### PR TITLE
Validate rate and discount

### DIFF
--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -298,6 +298,15 @@ class SlurmDB:
         ]
 
     def export_summary(self, start_time, end_time):
+        """Export a summary of usage and costs.
+
+        Rates represent a fixed cost per core-hour (for example, dollars
+        per core-hour) and must be non-negative. ``discount`` values are
+        fractional percentages, where ``0.2`` means a 20% discount, and
+        they must fall between 0 and 1, inclusive. A :class:`ValueError`
+        is raised if these constraints are violated.
+        """
+
         usage, totals = self.aggregate_usage(start_time, end_time)
         summary = {
             'summary': {},
@@ -330,6 +339,14 @@ class SlurmDB:
                 ovr = overrides.get(account, {})
                 rate = ovr.get('rate', base_rate)
                 discount = ovr.get('discount', 0)
+
+                if rate < 0:
+                    raise ValueError(f"Invalid rate {rate} for account {account}")
+                if not 0 <= discount <= 1:
+                    raise ValueError(
+                        f"Invalid discount {discount} for account {account}"
+                    )
+
                 acct_cost = vals['core_hours'] * rate
                 if 0 < discount < 1:
                     acct_cost *= 1 - discount


### PR DESCRIPTION
## Summary
- validate that rate is non-negative and discount is within [0,1]
- document rate/discount constraints in `export_summary`, clarifying rate is a fixed cost per core-hour
- add tests for invalid rate and discount values

## Testing
- `./test/check-application`


------
https://chatgpt.com/codex/tasks/task_e_6892c990530883248aff9ab695d374a9