### PR TITLE
Use SlurmDB context manager in schema script

### DIFF
--- a/src/slurm_schema.py
+++ b/src/slurm_schema.py
@@ -13,7 +13,6 @@ from slurmdb import SlurmDB
 
 def extract_schema(db: SlurmDB):
     """Return mapping of table names to column lists using a live DB."""
-    db.connect()
     schema = {}
     with db._conn.cursor() as cur:
         cur.execute("SHOW TABLES")
@@ -63,8 +62,12 @@ def main():
     else:
         if pymysql is None:
             raise RuntimeError('pymysql is required but not installed')
-        db = SlurmDB(config_file=args.conf, cluster=args.cluster, slurm_conf=args.slurm_conf)
-        schema = extract_schema(db)
+        with SlurmDB(
+            config_file=args.conf,
+            cluster=args.cluster,
+            slurm_conf=args.slurm_conf,
+        ) as db:
+            schema = extract_schema(db)
 
     with open(args.output, 'w') as fh:
         json.dump(schema, fh, indent=2)


### PR DESCRIPTION
## Summary
- use `SlurmDB` as a context manager in `slurm_schema` for automatic connection cleanup
- extend unit tests to ensure connections are closed after extracting schema

## Testing
- `test/check-application`

------
https://chatgpt.com/codex/tasks/task_e_6892c9952c508324ba7e41f2de3acc33