### PR TITLE
Add dependency manifest and reference in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Install Python lint deps
-        run: pip install flake8
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
       - name: Python lint
         run: flake8 src test
       - name: Set up Node
@@ -38,10 +38,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
       - name: Python unit tests
-        run: |
-          pip install pytest >/dev/null 2>&1
-          PYTHONPATH=src python test/unit/slurmdb_validation.test.py
+        run: PYTHONPATH=src python test/unit/slurmdb_validation.test.py
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -57,6 +57,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -72,7 +74,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Install Bandit
-        run: pip install bandit
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
       - name: Run Bandit
         run: bandit -r src

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ SlurmCostManager/
 
 ## 🧰 Installation & Development
 
+First install the Python dependencies used for database access, tests, and linting:
+
+```bash
+pip install -r requirements.txt
+```
+
 Recommend using the **Cockpit Starter Kit** workflow to scaffold and build your plugin:
 
 - Use `make devel-install` to symlink your dist output into `~/.local/share/cockpit/` for live development.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pymysql
+flake8
+pytest
+bandit


### PR DESCRIPTION
## Summary
- add `requirements.txt` with runtime, lint, and test dependencies
- document installing dependencies in the README
- use the requirements file in the CI workflow

## Testing
- `flake8 src test` *(fails: line-length and blank-line errors)*
- `bandit -r src` *(1 medium issue detected)*
- `./test/check-application`
- `npx eslint src test --ext .js` *(fails: no ESLint configuration found)*

------
https://chatgpt.com/codex/tasks/task_e_6892cfbd5b248324a2187f82256f457a