### PR TITLE
Validate invoices against schema

### DIFF
--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -277,11 +277,24 @@ class SlurmDB:
         return agg, totals
 
     def fetch_invoices(self, start_date=None, end_date=None):
-        """Fetch invoice metadata from the database if present."""
+        """Fetch invoice metadata from the database if present.
+
+        Each invoice entry is validated against ``invoice-schema.json``.
+        Invalid records are logged and skipped.
+        """
         if start_date:
             start_date = self._validate_time(start_date, "start_date")
         if end_date:
             end_date = self._validate_time(end_date, "end_date")
+
+        schema_path = os.path.join(os.path.dirname(__file__), "invoice-schema.json")
+        try:
+            with open(schema_path) as sfh:
+                schema = json.load(sfh)
+        except OSError as e:
+            logging.error("Failed to read invoice schema %s: %s", schema_path, e)
+            return []
+
         self.connect()
         with self._conn.cursor() as cur:
             cur.execute("SHOW TABLES LIKE 'invoices'")
@@ -290,21 +303,32 @@ class SlurmDB:
 
             if start_date and end_date:
                 query = (
-                    "SELECT file, invoice_date FROM invoices "
+                    "SELECT id, file, invoice_date, size, archived FROM invoices "
                     "WHERE invoice_date >= %s AND invoice_date <= %s"
                 )
                 cur.execute(query, (start_date, end_date))
             else:
-                query = "SELECT file, invoice_date FROM invoices"
+                query = "SELECT id, file, invoice_date, size, archived FROM invoices"
                 cur.execute(query)
             rows = cur.fetchall()
-        return [
-            {
-                'file': r.get('file'),
-                'date': r.get('invoice_date'),
+
+        invoices = []
+        for r in rows:
+            inv = {
+                "id": r.get("id"),
+                "filename": r.get("file"),
+                "date": r.get("invoice_date"),
             }
-            for r in rows
-        ]
+            if r.get("size") is not None:
+                inv["size"] = r.get("size")
+            if r.get("archived") is not None:
+                inv["archived"] = r.get("archived")
+            try:
+                jsonschema.validate(inv, schema)
+                invoices.append(inv)
+            except jsonschema.ValidationError as e:
+                logging.warning("Invalid invoice record skipped: %s", e.message)
+        return invoices
 
     def export_summary(self, start_time, end_time):
         """Export a summary of usage and costs.

--- a/test/unit/invoice_retrieval.test.py
+++ b/test/unit/invoice_retrieval.test.py
@@ -4,38 +4,67 @@ from slurmdb import SlurmDB
 
 
 class FakeCursor:
-    def __init__(self):
+    def __init__(self, rows):
         self.last_query = None
+        self.rows = rows
+
     def __enter__(self):
         return self
+
     def __exit__(self, exc_type, exc, tb):
         pass
+
     def execute(self, query, params=None):
         self.last_query = query
         self.params = params
+
     def fetchone(self):
         if "SHOW TABLES" in self.last_query:
-            return ('invoices',)
+            return ("invoices",)
         return None
+
     def fetchall(self):
-        return [{'file': 'inv1.pdf', 'invoice_date': '2023-10-01'}]
+        return self.rows
 
 
 class FakeConn:
+    def __init__(self, rows):
+        self.rows = rows
+
     def cursor(self):
-        return FakeCursor()
+        return FakeCursor(self.rows)
 
 
 class InvoiceRetrievalTests(unittest.TestCase):
-    def test_fetch_invoices_returns_rows(self):
+    def _make_db(self, rows):
         db = SlurmDB()
-        db._conn = FakeConn()
-        with mock.patch.object(SlurmDB, 'connect', lambda self: None):
-            invoices = db.fetch_invoices('2023-10-01', '2023-10-31')
+        db._conn = FakeConn(rows)
+        return db
+
+    def test_fetch_invoices_returns_rows(self):
+        rows = [
+            {"id": "1", "file": "inv1.pdf", "invoice_date": "2023-10-01"}
+        ]
+        db = self._make_db(rows)
+        with mock.patch.object(SlurmDB, "connect", lambda self: None):
+            invoices = db.fetch_invoices("2023-10-01", "2023-10-31")
         self.assertEqual(len(invoices), 1)
-        self.assertEqual(invoices[0]['file'], 'inv1.pdf')
-        self.assertEqual(invoices[0]['date'], '2023-10-01')
+        self.assertEqual(invoices[0]["filename"], "inv1.pdf")
+        self.assertEqual(invoices[0]["date"], "2023-10-01")
+
+    def test_invalid_invoice_skipped(self):
+        rows = [
+            {"id": "1", "file": "inv1.pdf", "invoice_date": "2023-10-01"},
+            {"id": "2", "invoice_date": "2023-10-01"},  # missing filename
+        ]
+        db = self._make_db(rows)
+        with mock.patch.object(SlurmDB, "connect", lambda self: None):
+            with self.assertLogs(level="WARNING") as log:
+                invoices = db.fetch_invoices("2023-10-01", "2023-10-31")
+        self.assertEqual(len(invoices), 1)
+        self.assertIn("Invalid invoice record skipped", log.output[0])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- validate invoice entries in SlurmDB.fetch_invoices against invoice-schema.json and drop invalid records
- return structured invoice metadata with id, filename, date, size, archived
- test valid invoice retrieval and skipping of invalid invoices

## Testing
- `PYTHONPATH=src python test/unit/invoice_retrieval.test.py`

------
https://chatgpt.com/codex/tasks/task_e_6892d341161083249f985f4fca3d1c2c