### PR TITLE
Handle missing jsonschema and remove inline styles

### DIFF
--- a/src/slurmcostmanager.css
+++ b/src/slurmcostmanager.css
@@ -110,6 +110,22 @@ nav button:hover {
   height: 300px;
 }
 
+.my-1 {
+  margin: 1em 0;
+}
+
+.mt-05 {
+  margin-top: 0.5em;
+}
+
+.mt-1 {
+  margin-top: 1em;
+}
+
+.ml-05 {
+  margin-left: 0.5em;
+}
+
 .rates-table {
   border-collapse: collapse;
   margin-top: 0.5em;

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -184,7 +184,7 @@ function Summary({ summary, details, daily, monthly, yearly }) {
     ),
     React.createElement(
       'div',
-      { style: { margin: '1em 0' } },
+      { className: 'my-1' },
       React.createElement(
         'button',
         { onClick: downloadInvoice },
@@ -559,19 +559,19 @@ function Rates({ onRatesUpdated }) {
     ),
     React.createElement(
       'button',
-      { onClick: addOverride, style: { marginTop: '0.5em' } },
+      { onClick: addOverride, className: 'mt-05' },
       'Add Override'
     ),
     React.createElement(
       'div',
-      { style: { marginTop: '1em' } },
+      { className: 'mt-1' },
       React.createElement(
         'button',
         { onClick: save, disabled: saving },
         'Save'
       ),
       saving && React.createElement('span', null, ' Saving...'),
-      status && React.createElement('span', { style: { marginLeft: '0.5em' } }, status)
+      status && React.createElement('span', { className: 'ml-05' }, status)
     )
   );
 }

--- a/src/slurmdb.py
+++ b/src/slurmdb.py
@@ -342,6 +342,9 @@ class SlurmDB:
             raise
         if not rates_missing:
             schema_path = os.path.join(os.path.dirname(__file__), 'rates-schema.json')
+            if jsonschema is None:
+                logging.error("jsonschema is required but not installed")
+                raise RuntimeError("jsonschema is required but not installed")
             try:
                 with open(schema_path) as sfh:
                     schema = json.load(sfh)


### PR DESCRIPTION
## Summary
- raise a clear error when `jsonschema` dependency is missing
- replace inline styles with CSS classes to satisfy CSP

## Testing
- `./test/check-application`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892d61ee0f483249bcea52307205574