### PR TITLE
Bundle Bootstrap assets locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "ajv": "^8.17.1",
+        "bootstrap": "^5.3.7",
         "chart.js": "^4.4.0",
         "jspdf": "^2.5.1",
         "react": "^18.2.0",
@@ -1766,6 +1767,17 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2269,6 +2281,25 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.25.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "chart.js": "^4.4.0",
     "jspdf": "^2.5.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "bootstrap": "^5.3.7"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",

--- a/src/slurmcostmanager.html
+++ b/src/slurmcostmanager.html
@@ -4,10 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SlurmCostManager</title>
+  <link rel="stylesheet" href="bootstrap.min.css" />
 </head>
 <body>
   <div id="root">Loading...</div>
   <script src="../base1/cockpit.js"></script>
+  <script src="bootstrap.bundle.min.js"></script>
   <script src="slurmcostmanager.js"></script>
 </body>
 </html>

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -3,6 +3,8 @@ const { useState, useEffect, useRef, useCallback } = React;
 const ReactDOM = require('react-dom/client');
 const Chart = require('chart.js/auto');
 const { jsPDF } = require('jspdf');
+require('bootstrap/dist/css/bootstrap.min.css');
+require('bootstrap/dist/js/bootstrap.bundle.min.js');
 if (typeof document !== 'undefined') {
   require('./slurmcostmanager.css');
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,16 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /bootstrap\.bundle\.min\.js$/,
+        type: 'asset/resource',
+        generator: { filename: 'bootstrap.bundle.min.js' },
+      },
+      {
+        test: /bootstrap\.min\.css$/,
+        type: 'asset/resource',
+        generator: { filename: 'bootstrap.min.css' },
+      },
+      {
         test: /\.js$/,
         exclude: /node_modules/,
         use: {
@@ -31,7 +41,7 @@ module.exports = {
     splitChunks: false,
     runtimeChunk: false,
     minimize: true,
-    minimizer: ['...', new CssMinimizerPlugin()],
+    minimizer: ['...', new CssMinimizerPlugin({ exclude: /bootstrap\.min\.css/ })],
   },
   plugins: [
     new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),


### PR DESCRIPTION
## Summary
- Add Bootstrap as a dependency and configure webpack to emit its CSS and JS into `dist`
- Require Bootstrap assets during bundling and reference them from `slurmcostmanager.html`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892dde4e25c8324833bd6467f46199e