### PR TITLE
Avoid inline CSS to satisfy CSP

### DIFF
--- a/src/slurmcostmanager.html
+++ b/src/slurmcostmanager.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SlurmCostManager</title>
   <link rel="stylesheet" href="bootstrap.min.css" />
+  <link rel="stylesheet" href="slurmcostmanager.css" />
 </head>
 <body>
   <div id="root">Loading...</div>

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -3,9 +3,10 @@ const { useState, useEffect, useRef, useCallback } = React;
 const ReactDOM = require('react-dom/client');
 const Chart = require('chart.js/auto');
 const { jsPDF } = require('jspdf');
-require('bootstrap/dist/css/bootstrap.min.css');
-require('bootstrap/dist/js/bootstrap.bundle.min.js');
 if (typeof document !== 'undefined') {
+  require('bootstrap/dist/css/bootstrap.min.css');
+  require('bootstrap/dist/js/bootstrap.bundle.min.js');
+  // Copy custom styles to the final build without injecting a <style> tag
   require('./slurmcostmanager.css');
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,11 @@ module.exports = {
         generator: { filename: 'bootstrap.min.css' },
       },
       {
+        test: /slurmcostmanager\.css$/,
+        type: 'asset/resource',
+        generator: { filename: 'slurmcostmanager.css' },
+      },
+      {
         test: /\.js$/,
         exclude: /node_modules/,
         use: {
@@ -41,7 +46,7 @@ module.exports = {
     splitChunks: false,
     runtimeChunk: false,
     minimize: true,
-    minimizer: ['...', new CssMinimizerPlugin({ exclude: /bootstrap\.min\.css/ })],
+    minimizer: ['...', new CssMinimizerPlugin({ exclude: /bootstrap\.min\.css|slurmcostmanager\.css/ })],
   },
   plugins: [
     new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),


### PR DESCRIPTION
## Summary
- load Bootstrap and custom styles only in browser context
- serve component stylesheets as standalone files and adjust webpack to emit them

## Testing
- `npm run build`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6892e0d05aac832491d602f58890dfd0