### PR TITLE
Use Bootstrap table styling

### DIFF
--- a/src/slurmcostmanager.css
+++ b/src/slurmcostmanager.css
@@ -33,25 +33,6 @@ nav button:hover {
   overflow-x: auto;
 }
 
-.summary-table th {
-  text-align: left;
-  padding-right: 1em;
-}
-
-.details-table,
-.summary-table {
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.details-table th,
-.details-table td,
-.summary-table th,
-.summary-table td {
-  border: 1px solid #ccc;
-  padding: 0.25em 0.5em;
-}
-
 .invoice-list {
   list-style: none;
   padding: 0;
@@ -81,30 +62,6 @@ nav button:hover {
   cursor: pointer;
 }
 
-.users-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 0.5em;
-}
-
-.users-table th,
-.users-table td {
-  border: 1px solid #ccc;
-  padding: 0.25em 0.5em;
-}
-
-.jobs-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 0.5em;
-}
-
-.jobs-table th,
-.jobs-table td {
-  border: 1px solid #ccc;
-  padding: 0.25em 0.5em;
-}
-
 .chart-container {
   position: relative;
   height: 300px;
@@ -124,22 +81,6 @@ nav button:hover {
 
 .ml-05 {
   margin-left: 0.5em;
-}
-
-.rates-table {
-  border-collapse: collapse;
-  margin-top: 0.5em;
-}
-
-.rates-table th,
-.rates-table td {
-  border: 1px solid #ccc;
-  padding: 0.25em 0.5em;
-}
-
-.rates-table input {
-  width: 100%;
-  box-sizing: border-box;
 }
 
 @media (max-width: 600px) {

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -159,7 +159,7 @@ function Summary({ summary, details, daily, monthly, yearly }) {
       { className: 'table-container' },
       React.createElement(
         'table',
-        { className: 'summary-table' },
+        { className: 'table table-striped table-bordered' },
         React.createElement(
           'tbody',
           null,
@@ -207,7 +207,7 @@ function Summary({ summary, details, daily, monthly, yearly }) {
 function JobDetails({ jobs }) {
   return React.createElement(
     'table',
-    { className: 'jobs-table' },
+    { className: 'table table-striped table-bordered' },
     React.createElement(
       'thead',
       null,
@@ -242,7 +242,7 @@ function UserDetails({ users }) {
   }
   return React.createElement(
     'table',
-    { className: 'users-table' },
+    { className: 'table table-striped table-bordered' },
     React.createElement(
       'thead',
       null,
@@ -304,7 +304,7 @@ function Details({ details }) {
       { className: 'table-container' },
       React.createElement(
         'table',
-        { className: 'details-table' },
+        { className: 'table table-striped table-bordered' },
         React.createElement(
           'thead',
           null,
@@ -495,6 +495,7 @@ function Rates({ onRatesUpdated }) {
           type: 'number',
           step: '0.001',
           value: config.defaultRate,
+          className: 'form-control',
           onChange: e =>
             setConfig({ ...config, defaultRate: e.target.value })
         })
@@ -503,7 +504,7 @@ function Rates({ onRatesUpdated }) {
     React.createElement('h3', null, 'Account Overrides'),
     React.createElement(
       'table',
-      { className: 'rates-table' },
+      { className: 'table table-striped table-bordered' },
       React.createElement(
         'thead',
         null,
@@ -526,6 +527,7 @@ function Rates({ onRatesUpdated }) {
             React.createElement('td', null,
               React.createElement('input', {
                 value: o.account,
+                className: 'form-control',
                 onChange: e =>
                   updateOverride(idx, 'account', e.target.value)
               })
@@ -535,6 +537,7 @@ function Rates({ onRatesUpdated }) {
                 type: 'number',
                 step: '0.001',
                 value: o.rate,
+                className: 'form-control',
                 onChange: e =>
                   updateOverride(idx, 'rate', e.target.value)
               })
@@ -544,6 +547,7 @@ function Rates({ onRatesUpdated }) {
                 type: 'number',
                 step: '0.01',
                 value: o.discount,
+                className: 'form-control',
                 onChange: e =>
                   updateOverride(idx, 'discount', e.target.value)
               })


### PR DESCRIPTION
## Summary
- Replace custom table class names with Bootstrap `table table-striped table-bordered`
- Drop redundant table styles and rely on Bootstrap defaults
- Style rate inputs with `form-control` for consistent layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `make check` *(fails: SyntaxError: Invalid or unexpected token in bootstrap.min.css)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892e0f42bd483249eb215f2899ccb93