### PR TITLE
Add analytics widgets and filtering to dashboard

### DIFF
--- a/src/slurmcostmanager.css
+++ b/src/slurmcostmanager.css
@@ -132,3 +132,60 @@ nav button:hover {
     margin: 0.5em 0;
   }
 }
+.kpi-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  margin-bottom: 1em;
+}
+.kpi-tile {
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 1em;
+  flex: 0 0 200px;
+  position: relative;
+  width: 200px;
+  height: 120px;
+}
+.kpi-label {
+  font-size: 0.9em;
+  color: #555;
+}
+.kpi-value {
+  font-size: 2em;
+  font-weight: bold;
+}
+.kpi-chart {
+  width: 180px;
+  height: 60px;
+  display: block;
+}
+.pi-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1em;
+}
+.pi-table th,
+.pi-table td {
+  border: 1px solid #ccc;
+  padding: 0.25em 0.5em;
+}
+.pi-bar {
+  height: 8px;
+  background: #4e79a7;
+}
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  align-items: center;
+  margin-bottom: 1em;
+}
+.filter-bar select,
+.filter-bar button {
+  padding: 0.25em;
+}
+.pagination {
+  margin-top: 0.5em;
+}


### PR DESCRIPTION
## Summary
- Add KPI tiles with sparkline, gauge, bullet chart and historical/forecast usage charts
- Show top Slurm accounts and PI consumption visuals
- Introduce filter controls, paginated job table and success/failure chart in details view
- Fix chart sizing by disabling responsive resizing and constraining KPI tiles

## Testing
- `make check` *(warning: Invalid JSON in rate configuration: Expected property name or '}' in JSON at position 2)*

------
https://chatgpt.com/codex/tasks/task_e_6893e01927bc83248171841cac854c35