### PR TITLE
Reorder summary charts and add table spacing

### DIFF
--- a/src/slurmcostmanager.css
+++ b/src/slurmcostmanager.css
@@ -31,6 +31,8 @@ nav button:hover {
 
 .table-container {
   overflow-x: auto;
+  width: 350px;
+  margin: 1em;
 }
 
 .summary-table th {

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -495,12 +495,12 @@ function Summary({ summary, details, daily, monthly }) {
           })
       })
     ),
-    React.createElement('h3', null, 'Historical CPU/GPU-hrs (monthly)'),
-    React.createElement(HistoricalUsageChart, { monthly }),
+    React.createElement('h3', null, 'Top 10 PIs by consumption'),
+    React.createElement(PiConsumptionTable, { details }),
     React.createElement('h3', null, 'CPU/GPU-hrs per Slurm account'),
     React.createElement(AccountsChart, { details }),
-    React.createElement('h3', null, 'Top 10 PIs by consumption'),
-    React.createElement(PiConsumptionTable, { details })
+    React.createElement('h3', null, 'Historical CPU/GPU-hrs (monthly)'),
+    React.createElement(HistoricalUsageChart, { monthly })
   );
 }
 


### PR DESCRIPTION
## Summary
- Give summary table a fixed width and margin to separate it from KPI tiles
- Reorder summary view to show Top 10 PIs before account and historical charts

## Testing
- `test/check-application`


------
https://chatgpt.com/codex/tasks/task_e_68941ef62c8c83249fd74ef6cb0f944d