### PR TITLE
Replace PI consumption table with pie chart

### DIFF
--- a/src/slurmcostmanager.css
+++ b/src/slurmcostmanager.css
@@ -164,20 +164,6 @@ nav button:hover {
   height: 60px;
   display: block;
 }
-.pi-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 1em;
-}
-.pi-table th,
-.pi-table td {
-  border: 1px solid #ccc;
-  padding: 0.25em 0.5em;
-}
-.pi-bar {
-  height: 8px;
-  background: #4e79a7;
-}
 .filter-bar {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- show top 10 PIs as fixed-size pie chart with legend labels
- drop unused PI table styling

## Testing
- `make check` *(fails: Unable to read dump file test/test_db_dump.sql)*

------
https://chatgpt.com/codex/tasks/task_e_6894208481708324bc0684cf18fb6e85