### PR TITLE
Use test fixtures for schema and slurmdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ python3 src/slurm_schema.py --output schema.json
 The resulting `schema.json` file can be compared with the list of
 tables and columns from your deployment.
 
+### Testing with sample SlurmDB data
+
+For unit tests and local development the repository includes two fixtures
+under `test/`:
+
+- `example_slurm_schema_for_testing.json` – a pre-generated mapping of
+  tables to columns for a minimal Slurm accounting database.
+- `example_slurmdb_for_testing.sql` – a small SQL dump containing the
+  corresponding table definitions and a few dummy rows.
+
+These files allow tests to verify table and column presence and operate on
+sample data without requiring access to a live SlurmDB instance.
+
 ## 📝 Development Notes
 
 - Your UI components can access system files or commands using `cockpit.file()` and other Cockpit APIs.

--- a/test/unit/slurm_schema_dump.test.py
+++ b/test/unit/slurm_schema_dump.test.py
@@ -4,7 +4,7 @@ from slurm_schema import extract_schema_from_dump
 
 class SlurmSchemaDumpTests(unittest.TestCase):
     def test_job_table_uses_cpus_req(self):
-        schema = extract_schema_from_dump('test/test_db_dump.sql')
+        schema = extract_schema_from_dump('test/example_slurmdb_for_testing.sql')
         cols = schema.get('localcluster_job_table', [])
         self.assertIn('cpus_req', cols)
         self.assertNotIn('cpus_alloc', cols)

--- a/test/unit/slurmdb_validation.test.py
+++ b/test/unit/slurmdb_validation.test.py
@@ -1,6 +1,7 @@
 import unittest
+import json
 from slurmdb import SlurmDB
-from slurm_schema import extract_schema_from_dump, extract_schema
+from slurm_schema import extract_schema
 
 class SlurmDBValidationTests(unittest.TestCase):
     def test_invalid_cluster_rejected(self):
@@ -150,7 +151,8 @@ class SlurmDBValidationTests(unittest.TestCase):
         self.assertIsNone(db._conn)
 
     def test_fetch_usage_records_uses_cpus_req_if_alloc_missing(self):
-        schema = extract_schema_from_dump('test/test_db_dump.sql')
+        with open('test/example_slurm_schema_for_testing.json') as fh:
+            schema = json.load(fh)
         job_cols = schema.get('localcluster_job_table', [])
 
         class FakeCursor:


### PR DESCRIPTION
## Summary
- document sample SlurmDB schema and dump fixtures for test use
- switch tests to use example schema JSON and SQL dump

## Testing
- `for f in test/unit/*.test.py; do PYTHONPATH=src python $f; done`
- `for f in test/unit/*.test.js; do node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_6894215e41c88324ab06217b7871a48b