### PR TITLE
Remove Top 10 PIs chart

### DIFF
--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -515,8 +515,6 @@ function Summary({ summary, details, daily, monthly }) {
           })
       })
     ),
-    React.createElement('h3', null, 'Top 10 PIs by consumption'),
-    React.createElement(PiConsumptionChart, { details }),
     React.createElement('h3', null, 'CPU/GPU-hrs per Slurm account'),
     React.createElement(AccountsChart, { details }),
     React.createElement('h3', null, 'Historical CPU/GPU-hrs (monthly)'),


### PR DESCRIPTION
## Summary
- keep the Top 10 PIs KPI tile and remove the standalone Top 10 PIs chart

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689423bd71588324b2dfd9220b26669a