### PR TITLE
Add GPU-hours KPI tile and backend support

### DIFF
--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -442,6 +442,7 @@ function SuccessFailChart({ data }) {
 
 function Summary({ summary, details, daily, monthly }) {
   const sparklineData = daily.map(d => d.core_hours);
+  const gpuSparklineData = daily.map(d => d.gpu_hours || 0);
   const ratio = summary.projected_revenue
     ? summary.total / summary.projected_revenue
     : 1;
@@ -477,6 +478,12 @@ function Summary({ summary, details, daily, monthly }) {
             null,
             React.createElement('th', null, 'Total Core Hours'),
             React.createElement('td', null, summary.core_hours)
+          ),
+          React.createElement(
+            'tr',
+            null,
+            React.createElement('th', null, 'Total GPU Hours'),
+            React.createElement('td', null, summary.gpu_hours || 0)
           )
         )
       )
@@ -488,6 +495,12 @@ function Summary({ summary, details, daily, monthly }) {
         label: 'Total CPU-hours',
         value: summary.core_hours,
         renderChart: () => React.createElement(KpiSparkline, { data: sparklineData })
+      }),
+      React.createElement(KpiTile, {
+        label: 'Total GPU-hours',
+        value: summary.gpu_hours,
+        renderChart: () =>
+          React.createElement(KpiSparkline, { data: gpuSparklineData })
       }),
       React.createElement(KpiTile, {
         label: 'Cost recovery ratio',

--- a/test/unit/billing_summary.test.py
+++ b/test/unit/billing_summary.test.py
@@ -10,6 +10,7 @@ class BillingSummaryTests(unittest.TestCase):
             '2023-10': {
                 'acct': {
                     'core_hours': 10.0,
+                    'gpu_hours': 5.0,
                     'users': {
                         'user1': {'core_hours': 10.0, 'jobs': {}}
                     },
@@ -20,7 +21,14 @@ class BillingSummaryTests(unittest.TestCase):
         with mock.patch.object(
             SlurmDB,
             'aggregate_usage',
-            return_value=(usage, {'daily': {}, 'monthly': {}, 'yearly': {}}),
+            return_value=(usage, {
+                'daily': {},
+                'monthly': {},
+                'yearly': {},
+                'daily_gpu': {},
+                'monthly_gpu': {},
+                'yearly_gpu': {},
+            }),
         ):
             with mock.patch.object(SlurmDB, 'fetch_invoices', return_value=invoices):
                 db = SlurmDB()
@@ -28,7 +36,9 @@ class BillingSummaryTests(unittest.TestCase):
         self.assertEqual(summary['summary']['total'], 0.2)
         self.assertEqual(summary['details'][0]['account'], 'acct')
         self.assertEqual(summary['details'][0]['core_hours'], 10.0)
+        self.assertEqual(summary['details'][0]['gpu_hours'], 5.0)
         self.assertEqual(summary['details'][0]['cost'], 0.2)
+        self.assertEqual(summary['summary']['gpu_hours'], 5.0)
         self.assertEqual(summary['invoices'][0]['file'], 'inv1.pdf')
 
     def test_export_summary_applies_overrides_and_discounts(self):


### PR DESCRIPTION
## Summary
- track GPU-hours in backend and expose in billing summaries
- show Total GPU-hours KPI with sparkline visualization
- cover GPU-hour aggregation with unit tests

## Testing
- `test/check-application`

------
https://chatgpt.com/codex/tasks/task_e_68942422e3508324b5328dbc75d2a21d