### PR TITLE
Discover slurm config path from service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,14 @@ The workflow tags the repository, builds packages, and publishes artifacts to Gi
 
 The `src/slurmdb.py` utility can connect to a running **SlurmDBD** instance and
 export usage metrics as JSON. Connection details are automatically scraped from
-`/etc/slurm/slurmdbd.conf` (or a custom path specified via the environment
-variable `SLURMDB_CONF` or the `--conf` flag). Environment variables
+`slurmdbd.conf` located alongside `slurm.conf` (discovered from
+`slurmctld.service` via the `ConditionPathExists` directive, defaulting to
+`/etc/slurm/slurm.conf`). A custom path can be specified via the environment
+variable `SLURMDB_CONF` or the `--conf` flag. Environment variables
 `SLURMDB_HOST`, `SLURMDB_PORT`, `SLURMDB_USER`, `SLURMDB_PASS` and `SLURMDB_DB`
 override any values found in the configuration file. The cluster prefix used to
-select the job tables is determined from `/etc/slurm/slurm.conf` but can be set
-using `SLURM_CLUSTER`, `--cluster` or `--slurm-conf`.
+select the job tables is determined from the Slurm configuration file. The
+setting can be overridden using `SLURM_CLUSTER`, `--cluster` or `--slurm-conf`.
 
 
 ```bash


### PR DESCRIPTION
## Summary
- read `slurmctld.service` to locate the `slurm.conf` path
- infer `slurmdbd.conf` from the same directory as `slurm.conf`
- document automatic slurm configuration discovery
- cover service file parsing with a unit test

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6894f18494e483249fdb16d75f34a182