### PR TITLE
Remove manual cluster core count configuration

### DIFF
--- a/src/rates-schema.json
+++ b/src/rates-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "RatesConfig",
-  "description": "Schema for core and GPU hour rate configuration",
+  "description": "Schema for core and GPU hour rate configuration; cluster core counts are derived from slurm.conf",
   "type": "object",
   "properties": {
     "defaultRate": {

--- a/src/rates.json
+++ b/src/rates.json
@@ -1,7 +1,6 @@
 {
   "defaultRate": 0.02,
   "defaultGpuRate": 0.2,
-  "clusterCores": 100,
   "historicalRates": {
     "2024-01": 0.015
   },

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -1023,22 +1023,6 @@ function Rates({ onRatesUpdated }) {
         })
       )
     ),
-    React.createElement(
-      'div',
-      null,
-      React.createElement(
-        'label',
-        null,
-        'Total Cluster Cores: ',
-        React.createElement('input', {
-          type: 'number',
-          step: '1',
-          value: config.clusterCores,
-          onChange: e =>
-            setConfig({ ...config, clusterCores: e.target.value })
-        })
-      )
-    ),
     React.createElement('h3', null, 'Account Overrides'),
     React.createElement(
       'table',

--- a/test/unit/billing_summary.test.py
+++ b/test/unit/billing_summary.test.py
@@ -207,7 +207,15 @@ class BillingSummaryTests(unittest.TestCase):
         ), mock.patch.object(SlurmDB, 'fetch_invoices', return_value=[]), mock.patch(
             'builtins.open', side_effect=fake_open
         ), mock.patch.object(
-            SlurmDB, 'cluster_resources', return_value={'cores': 100}
+            SlurmDB,
+            '_parse_slurm_conf',
+            return_value={
+                'nodes': 1,
+                'sockets': 1,
+                'cores': 100,
+                'threads': 1,
+                'gres': {},
+            },
         ):
             db = SlurmDB()
             summary = db.export_summary('2024-02-01', '2024-02-29')


### PR DESCRIPTION
## Summary
- Drop "Total Cluster Cores" field from settings UI
- Clarify rate schema and config to rely on cores parsed from slurm.conf
- Update billing summary test to use slurm.conf data instead of manual core count

## Testing
- `PYTHONPATH=src python test/unit/accounts_listing.test.py`
- `PYTHONPATH=src python test/unit/auth_boundaries.test.py`
- `PYTHONPATH=src python test/unit/billing_summary.test.py`
- `PYTHONPATH=src python test/unit/invoice_retrieval.test.py`
- `PYTHONPATH=src python test/unit/slurm_schema_dump.test.py`
- `PYTHONPATH=src python test/unit/slurmdb_validation.test.py`
- `node test/unit/calculator.test.js`
- `node test/unit/date_boundaries.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6895268667bc8324883dd43a0ec6db2d