### PR TITLE
Clear stale data when switching billing periods

### DIFF
--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -54,6 +54,12 @@ function useBillingData(period) {
 
   const load = useCallback(async () => {
     const id = ++requestIdRef.current;
+    // Clear out existing data while loading a new period so that views
+    // such as "Detailed Transactions" don't momentarily display data
+    // from the previously selected period (e.g. the fiscal year) when
+    // navigating directly between views.
+    setData(null);
+    setError(null);
     try {
       let json;
       if (window.cockpit && window.cockpit.spawn) {


### PR DESCRIPTION
## Summary
- Avoid showing year data when navigating directly to Detailed Transactions by clearing previous billing data before fetching a new period.

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68956829030c83249308ce71edd67a62