### PR TITLE
Display account and historical usage charts side by side

### DIFF
--- a/src/slurmcostmanager.css
+++ b/src/slurmcostmanager.css
@@ -186,3 +186,16 @@ nav button:hover {
 .pagination {
   margin-top: 0.5em;
 }
+
+/* Layout for side-by-side summary charts */
+.summary-charts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  margin-top: 1em;
+}
+
+.summary-chart {
+  flex: 1;
+  min-width: 300px;
+}

--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -692,10 +692,22 @@ function Summary({ summary, details = [], daily = [], monthly = [], yearly = [] 
           })
       })
     ),
-    React.createElement('h3', null, 'CPU/GPU-hrs per Slurm account'),
-    React.createElement(AccountsChart, { details }),
-    React.createElement('h3', null, historicalLabel),
-    React.createElement(HistoricalUsageChart, { data: historical })
+    React.createElement(
+      'div',
+      { className: 'summary-charts' },
+      React.createElement(
+        'div',
+        { className: 'summary-chart' },
+        React.createElement('h3', null, 'CPU/GPU-hrs per Slurm account'),
+        React.createElement(AccountsChart, { details })
+      ),
+      React.createElement(
+        'div',
+        { className: 'summary-chart' },
+        React.createElement('h3', null, historicalLabel),
+        React.createElement(HistoricalUsageChart, { data: historical })
+      )
+    )
   );
 }
 


### PR DESCRIPTION
## Summary
- show per-account and historical CPU/GPU-hrs charts next to each other on summary views
- add flexbox styling for side-by-side chart layout

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_689568a3ed54832481543e861c21c737