### PR TITLE
Display invoice export errors in UI

### DIFF
--- a/src/slurmcostmanager.js
+++ b/src/slurmcostmanager.js
@@ -789,6 +789,7 @@ function Details({
     account: '',
     user: ''
   });
+  const [error, setError] = useState(null);
 
   function toggle(account) {
     setExpanded(prev => (prev === account ? null : account));
@@ -900,9 +901,10 @@ function Details({
         'Thank you for your prompt payment. For questions regarding this invoice, please contact our office.'
     };
     try {
+      setError(null);
       const output = await window.cockpit.spawn(
         ['python3', `${PLUGIN_BASE}/invoice.py`],
-        { input: JSON.stringify(invoiceData), err: 'message' }
+        { input: JSON.stringify(invoiceData), err: 'out' }
       );
       const byteChars = atob(output.trim());
       const byteNumbers = new Array(byteChars.length);
@@ -920,6 +922,7 @@ function Details({
       URL.revokeObjectURL(url);
     } catch (e) {
       console.error(e);
+      setError(e.message || String(e));
     }
   }
 
@@ -957,7 +960,13 @@ function Details({
         );
       }),
       React.createElement('button', { onClick: exportCSV }, 'Export CSV'),
-      React.createElement('button', { onClick: exportInvoice }, 'Export Invoice')
+      React.createElement('button', { onClick: exportInvoice }, 'Export Invoice'),
+      error &&
+        React.createElement(
+          'span',
+          { className: 'error', style: { marginLeft: '0.5em' } },
+          error
+        )
     ),
     React.createElement(
       'div',


### PR DESCRIPTION
## Summary
- surface invoice generation failures to users
- capture `invoice.py` stderr and show message on PDF export errors

## Testing
- `for f in test/unit/*.test.js; do echo Running $f; node "$f"; done`
- `for f in test/unit/*.test.py; do echo Running $f; python3 "$f" >/tmp/test.log && tail -n 20 /tmp/test.log; done` *(fails: ModuleNotFoundError: No module named 'slurmdb')*


------
https://chatgpt.com/codex/tasks/task_e_68958554fa208324b540f490dd3897af