### PR TITLE
Display invoice export errors in UI

### DIFF
--- a/src/invoice.py
+++ b/src/invoice.py
@@ -13,12 +13,23 @@ import os
 import sys
 from datetime import datetime
 
-from reportlab.lib import colors
-from reportlab.lib.enums import TA_RIGHT
-from reportlab.lib.pagesizes import LETTER
-from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
-from reportlab.platypus import (SimpleDocTemplate, Paragraph, Spacer, Table,
-                                TableStyle)
+# Reportlab is required for PDF generation. If it's missing, emit a clear
+# error message on stderr so callers can surface the failure to users.
+try:
+    from reportlab.lib import colors
+    from reportlab.lib.enums import TA_RIGHT
+    from reportlab.lib.pagesizes import LETTER
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.platypus import (
+        SimpleDocTemplate,
+        Paragraph,
+        Spacer,
+        Table,
+        TableStyle,
+    )
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised via JS
+    print(str(exc), file=sys.stderr)
+    sys.exit(1)
 
 
 def _load_profile(base_dir):
@@ -174,8 +185,10 @@ def main():
 
     buffer = io.BytesIO()
     generate_invoice(buffer, invoice_data)
-    pdf_bytes = buffer.getvalue()
+    buffer.seek(0)
+    pdf_bytes = buffer.read()
     sys.stdout.write(base64.b64encode(pdf_bytes).decode("ascii"))
+    sys.stdout.flush()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- emit readable error when PDF dependencies are missing and flush buffer before encoding
- fail early when no usage data matches filters and surface generator output on decode errors

## Testing
- `for f in test/unit/*.test.js; do echo Running $f; node "$f"; done`
- `for f in test/unit/*.test.py; do echo Running $f; python3 "$f" >/tmp/test.log && tail -n 20 /tmp/test.log; done` *(fails: ModuleNotFoundError: No module named 'slurmdb', 'slurm_schema', 'pymysql')*

------
https://chatgpt.com/codex/tasks/task_e_68958554fa208324b540f490dd3897af