### PR TITLE
Use async fs for rate config loading

### DIFF
--- a/src/cost-calculator.js
+++ b/src/cost-calculator.js
@@ -1,26 +1,33 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 
 /**
  * Load rate configuration from rates.json.
  *
- * @returns {Object} rate configuration
+ * @returns {Promise<Object>} rate configuration
  */
-function loadRatesConfig() {
+async function loadRatesConfig() {
   const cfgPath = path.join(__dirname, 'rates.json');
   try {
-    const data = fs.readFileSync(cfgPath, 'utf8');
+    const data = await fs.readFile(cfgPath, 'utf8');
     return JSON.parse(data);
   } catch (e) {
     if (e.code === 'ENOENT') {
       return {};
     }
     if (e instanceof SyntaxError) {
-      console.error(`Invalid JSON in rate configuration: ${e.message}`);
+      console.error('Invalid JSON in rate configuration', {
+        path: cfgPath,
+        error: e.message,
+      });
     } else {
-      console.error(`Error loading rate configuration: ${e.message}`);
+      console.error('Error loading rate configuration', {
+        path: cfgPath,
+        error: e.message,
+        code: e.code,
+      });
     }
     throw e;
   }


### PR DESCRIPTION
## Summary
- refactor loadRatesConfig to read rates.json asynchronously with structured error logging
- update calculator tests to await async config loading

## Testing
- `node test/unit/calculator.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c02d41a0f88324a604c8595487bd4b