### PR TITLE
Raise profile load errors

### DIFF
--- a/src/invoice.py
+++ b/src/invoice.py
@@ -43,9 +43,10 @@ def _load_profile(base_dir):
         return {}
     except json.JSONDecodeError as exc:
         logging.error("Failed to parse %s: %s", path, exc)
+        raise
     except OSError as exc:
         logging.error("Unable to read %s: %s", path, exc)
-    return {}
+        raise
 
 
 def _profile_sections(profile):
@@ -198,7 +199,15 @@ def generate_invoice(buffer, invoice_data):
 
 def main():
     base_dir = os.path.dirname(os.path.abspath(__file__))
-    profile = _load_profile(base_dir)
+    try:
+        profile = _load_profile(base_dir)
+    except json.JSONDecodeError as exc:
+        print(f"Invalid institution profile: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as exc:
+        print(f"Unable to read institution profile: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     invoice_data = json.load(sys.stdin)
 
     # Fill in profile-based sections if not provided

--- a/test/unit/profile_loading.test.py
+++ b/test/unit/profile_loading.test.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 from unittest import mock
 import logging
+import json
 
 from invoice import _load_profile
 
@@ -18,14 +19,16 @@ class LoadProfileTests(unittest.TestCase):
             with open(path, "w", encoding="utf-8") as fh:
                 fh.write("{invalid")
             with self.assertLogs(level="ERROR") as cm:
-                self.assertEqual(_load_profile(td), {})
+                with self.assertRaises(json.JSONDecodeError):
+                    _load_profile(td)
             self.assertIn("Failed to parse", cm.output[0])
 
     def test_os_error_logs_error(self):
         with tempfile.TemporaryDirectory() as td:
             with mock.patch("builtins.open", side_effect=PermissionError("denied")):
                 with self.assertLogs(level="ERROR") as cm:
-                    self.assertEqual(_load_profile(td), {})
+                    with self.assertRaises(OSError):
+                        _load_profile(td)
         self.assertIn("Unable to read", cm.output[0])
 
 


### PR DESCRIPTION
## Summary
- raise JSON parsing and OS errors when loading institution profile
- exit invoice generation with friendly messages on profile load errors
- expect exceptions in profile loading tests

## Testing
- `test/check-application`


------
https://chatgpt.com/codex/tasks/task_e_68c0b69bc8ac8324ab1a3eb4b4c0d22c